### PR TITLE
Remove gz

### DIFF
--- a/orbbec_description/package.xml
+++ b/orbbec_description/package.xml
@@ -9,8 +9,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>realsense2_gz_description</exec_depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/orbbec_description/urdf/gemini335L_336L_macro.urdf.xacro
+++ b/orbbec_description/urdf/gemini335L_336L_macro.urdf.xacro
@@ -165,7 +165,15 @@
       xyz="0 0 0" />
   </joint>
 
-  <link name="${prefix}_color_frame" />
+  <link name="${prefix}_color_frame" >
+    <inertial>
+        <mass value="0.01" />
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <inertia ixx="0.001"  ixy="0" ixz="0"
+                 iyx="0" iyy="0.001" iyz="0"
+                 izx="0" izy="0" izz="0.001" />
+      </inertial>
+  </link>
   <joint
     name="${prefix}_color_joint"
     type="fixed">

--- a/orbbec_description/urdf/gemini335L_336L_macro.urdf.xacro
+++ b/orbbec_description/urdf/gemini335L_336L_macro.urdf.xacro
@@ -5,11 +5,7 @@
 <xacro:macro name="gemini_335L_336L" params="
     parent
     prefix:='camera'
-    *origin
-    sim_gazebo:=false
-    gz_fps:='5'
-    gz_image_width:='848'
-    gz_image_height:='530'">
+    *origin">
 
   <!-- The original link started with camera_link -->
   <joint name="${prefix}_gemini_mount_fixed_joint" type="fixed">
@@ -198,22 +194,6 @@
     <axis
       xyz="0 0 0" />
   </joint>
-
-  <xacro:if value="${sim_gazebo}">
-    <!-- Use the realsense2_gz_description which can simulate a generic depth camera -->
-    <xacro:include filename="$(find realsense2_gz_description)/urdf/rgbd_camera.gazebo.xacro" />
-    <!-- TODO: Upstream changes required for a triggered RBGD camera -->
-    <xacro:gazebo_rgbd
-      name="${prefix}"
-      gz_topic_name="${prefix}"
-      fps="${gz_fps}"
-      image_width="${gz_image_width}"
-      image_height="${gz_image_height}"
-      h_fov="${94 * pi/180}"
-      v_fov="${68 * pi/180}"
-      min_depth="0.17"
-      max_depth="6.0" />
-  </xacro:if>
 
 </xacro:macro>
 </robot>

--- a/orbbec_description/urdf/gemini335L_336L_macro.urdf.xacro
+++ b/orbbec_description/urdf/gemini335L_336L_macro.urdf.xacro
@@ -47,7 +47,7 @@
 
   <link name="${prefix}_color_screw_frame" />
   <joint
-    name="${prefix}_color_screw_frame_joint"
+    name="${prefix}_color_screw_joint"
     type="fixed">
     <origin
       xyz="0 0 0"
@@ -62,7 +62,7 @@
 
   <link name="${prefix}_IMU_frame" />
   <joint
-    name="${prefix}_IMU_frame_joint"
+    name="${prefix}_IMU_joint"
     type="fixed">
     <origin
       xyz="-0.002535 0.039634 0.013243"
@@ -77,7 +77,7 @@
 
   <link name="${prefix}_depth_frame" />
   <joint
-    name="${prefix}_depth_frame_joint"
+    name="${prefix}_depth_joint"
     type="fixed">
     <origin
       xyz="0.011715 0.0475 0.014311"
@@ -92,7 +92,7 @@
 
   <link name="${prefix}_depth_optical_frame" />
   <joint
-    name="${prefix}_depth_optical_frame_joint"
+    name="${prefix}_depth_optical_joint"
     type="fixed">
     <origin
       xyz="0 0 0"
@@ -107,7 +107,7 @@
 
   <link name="${prefix}_infra1_frame" />
   <joint
-    name="${prefix}_infra1_frame_joint"
+    name="${prefix}_infra1_joint"
     type="fixed">
     <origin
       xyz="0.011715 0.0475 0.014311"
@@ -122,7 +122,7 @@
 
   <link name="${prefix}_infra1_optical_frame" />
   <joint
-    name="${prefix}_infra1_optical_frame_joint"
+    name="${prefix}_infra1_optical_joint"
     type="fixed">
     <origin
       xyz="0 0 0"
@@ -137,7 +137,7 @@
 
   <link name="${prefix}_infra2_frame" />
   <joint
-    name="${prefix}_infra2_frame_joint"
+    name="${prefix}_infra2_joint"
     type="fixed">
     <origin
       xyz="0.011715 -0.0475 0.014311"
@@ -152,7 +152,7 @@
 
   <link name="${prefix}_infra2_optical_frame" />
   <joint
-    name="${prefix}_infra2_optical_frame_joint"
+    name="${prefix}_infra2_optical_joint"
     type="fixed">
     <origin
       xyz="0 0 0"
@@ -167,7 +167,7 @@
 
   <link name="${prefix}_color_frame" />
   <joint
-    name="${prefix}_color_frame_joint"
+    name="${prefix}_color_joint"
     type="fixed">
     <origin
       xyz="0.011715 0.02375 0.014311"
@@ -182,7 +182,7 @@
 
   <link name="${prefix}_color_optical_frame" />
   <joint
-    name="${prefix}_color_optical_frame_joint"
+    name="${prefix}_color_optical_joint"
     type="fixed">
     <origin
       xyz="0 0 0"

--- a/orbbec_description/urdf/gemini335Le_macro.urdf.xacro
+++ b/orbbec_description/urdf/gemini335Le_macro.urdf.xacro
@@ -5,11 +5,7 @@
 <xacro:macro name="gemini_335Le" params="
     parent
     name:='camera'
-    *origin
-    sim_gazebo:=false
-    gz_fps:='5'
-    gz_image_width:='848'
-    gz_image_height:='530'">
+    *origin">
 
   <!-- The original link started with camera_link -->
   <joint name="${name}_gemini_mount_fixed_joint" type="fixed">
@@ -198,22 +194,6 @@
     <axis
       xyz="0 0 0" />
   </joint>
-
-  <xacro:if value="${sim_gazebo}">
-    <!-- Use the realsense2_gz_description which can simulate a generic depth camera -->
-    <xacro:include filename="$(find realsense2_gz_description)/urdf/rgbd_camera.gazebo.xacro" />
-    <!-- TODO: Upstream changes required for a triggered RBGD camera -->
-    <xacro:gazebo_rgbd
-      name="${name}"
-      gz_topic_name="${name}"
-      fps="${gz_fps}"
-      image_width="${gz_image_width}"
-      image_height="${gz_image_height}"
-      h_fov="${94 * pi/180}"
-      v_fov="${68 * pi/180}"
-      min_depth="0.25"
-      max_depth="6.0" />
-  </xacro:if>
 
 </xacro:macro>
 </robot>

--- a/orbbec_description/urdf/gemini335Le_macro.urdf.xacro
+++ b/orbbec_description/urdf/gemini335Le_macro.urdf.xacro
@@ -52,7 +52,7 @@
 
   <link name="${name}_bottom_screw_frame" />
   <joint
-    name="${name}_bottom_screw_frame_joint"
+    name="${name}_bottom_screw_joint"
     type="fixed">
     <origin
       xyz="0 0 0"
@@ -67,7 +67,7 @@
 
   <link name="${name}_infra2_frame" />
   <joint
-    name="${name}_infra2_frame_joint"
+    name="${name}_infra2_joint"
     type="fixed">
     <origin
       xyz="0.034005 -0.0475 0.014048"
@@ -82,7 +82,7 @@
 
   <link name="${name}_infra2_optical_frame" />
   <joint
-    name="${name}_infra2_optical_frame_joint"
+    name="${name}_infra2_optical_joint"
     type="fixed">
     <origin
       xyz="0 0 0"
@@ -98,7 +98,7 @@
 
   <link name="${name}_infra1_frame" />
   <joint
-    name="${name}_infra1_frame_joint"
+    name="${name}_infra1_joint"
     type="fixed">
     <origin
       xyz="0.034005 0.0475 0.014048"
@@ -113,7 +113,7 @@
 
   <link name="${name}_infra1_optical_frame" />
   <joint
-    name="${name}_infra1_optical_frame_joint"
+    name="${name}_infra1_optical_joint"
     type="fixed">
     <origin
       xyz="0 0 0"
@@ -128,7 +128,7 @@
 
   <link name="${name}_depth_frame" />
   <joint
-    name="${name}_depth_frame_joint"
+    name="${name}_depth_joint"
     type="fixed">
     <parent
       link="${name}_infra1_frame" />
@@ -140,7 +140,7 @@
 
   <link name="${name}_depth_optical_frame" />
   <joint
-    name="${name}_depth_optical_frame_joint"
+    name="${name}_depth_optical_joint"
     type="fixed">
     <parent
       link="${name}_infra1_optical_frame" />
@@ -150,9 +150,17 @@
       xyz="0 0 0" />
   </joint>
 
-  <link name="${name}_color_frame" />
+  <link name="${name}_color_frame" >
+    <inertial>
+        <mass value="0.01" />
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <inertia ixx="0.001"  ixy="0" ixz="0"
+                 iyx="0" iyy="0.001" iyz="0"
+                 izx="0" izy="0" izz="0.001" />
+      </inertial>
+  </link>
   <joint
-    name="${name}_frame_frame_joint"
+    name="${name}_color_joint"
     type="fixed">
     <origin
       xyz="0.034014 0.02375 0.014048"
@@ -167,7 +175,7 @@
 
   <link name="${name}_color_optical_frame" />
   <joint
-    name="${name}_color_optical_frame_joint"
+    name="${name}_color_optical_joint"
     type="fixed">
     <origin
       xyz="0 0 0"
@@ -182,7 +190,7 @@
 
   <link name="${name}_imu_frame" />
   <joint
-    name="${name}_imu_frame_joint"
+    name="${name}_imu_joint"
     type="fixed">
     <origin
       xyz="0.019757 0.03619 0.013358"

--- a/orbbec_description/urdf/gemini_335_336.urdf.xacro
+++ b/orbbec_description/urdf/gemini_335_336.urdf.xacro
@@ -56,7 +56,7 @@ Stephen Brawner (brawner@gmail.com)
         </collision>
     </link>
 
-    <joint name="camera_bottom_screw_joint" type="fixed">
+    <joint name="camera_bottom_screw_frame_joint" type="fixed">
         <origin xyz="0 0 0" rpy="0 0 0" />
         <parent link="camera_link" />
         <child link="camera_bottom_screw_frame" />

--- a/orbbec_description/urdf/gemini_335_336.urdf.xacro
+++ b/orbbec_description/urdf/gemini_335_336.urdf.xacro
@@ -56,7 +56,7 @@ Stephen Brawner (brawner@gmail.com)
         </collision>
     </link>
 
-    <joint name="camera_bottom_screw_frame_joint" type="fixed">
+    <joint name="camera_bottom_screw_joint" type="fixed">
         <origin xyz="0 0 0" rpy="0 0 0" />
         <parent link="camera_link" />
         <child link="camera_bottom_screw_frame" />


### PR DESCRIPTION
This PR removes the dependency on `realsense2_gz_description` and enables compatibility with the newly refactored [gz_camera_descriptions](https://github.com/locusrobotics/realsense2_gz_description/pull/5) repo (had to add inertia to the color frame so that the simulated camera works.
<img width="1267" height="1071" alt="image" src="https://github.com/user-attachments/assets/657c46ee-80c6-41af-ae03-adb79ba31151" />

I also removed `frame` from the name in the joints (they are joints not frames).