### PR TITLE
APG-1816 Add lifecycle service to change state of camera pipelines/streaming

### DIFF
--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -32,6 +32,7 @@ set(dependencies
     camera_info_manager
     image_transport
     image_publisher
+    lifecycle_msgs
     OpenCV
     orbbec_camera_msgs
     rclcpp

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -37,6 +37,7 @@
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
+#include <lifecycle_msgs/srv/change_state.hpp>
 
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <camera_info_manager/camera_info_manager.hpp>
@@ -411,6 +412,11 @@ class OBCameraNode {
 
   void setDisparitySearchOffset();
 
+  // Lifecycle Service
+  void handleChangeStateRequest(
+      const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request> request,
+      std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response> response);  
+
  private:
   rclcpp::Node* node_ = nullptr;
   std::shared_ptr<ob::Device> device_ = nullptr;
@@ -502,6 +508,8 @@ class OBCameraNode {
   rclcpp::Service<CameraTrigger>::SharedPtr send_service_trigger_srv_;
   rclcpp::Service<SetFilter>::SharedPtr set_filter_srv_;
   rclcpp::Service<CameraTrigger>::SharedPtr capture_camera_images_srv_;
+  // Lifecycle Service
+  rclcpp::Service<lifecycle_msgs::srv::ChangeState>::SharedPtr change_state_srv_;
 
 
   std::atomic_bool service_capture_started_{false};

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -316,10 +316,6 @@ class OBCameraNode {
                          std::shared_ptr<SetFilter ::Response>& response);
   void setSYNCHostimeCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request>& request,
                               std::shared_ptr<std_srvs::srv::SetBool::Response>& response);
-    // Lifecycle Service
-  void handleChangeStateRequest(
-      const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request> request,
-      std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response> response);  
   void resetCaptureServiceVariables();
   void sendSoftwareTriggerCallback(const std::shared_ptr<CameraTrigger::Request>& request,
                                    std::shared_ptr<CameraTrigger::Response>& response);
@@ -343,6 +339,10 @@ class OBCameraNode {
 
   void setIRLongExposureCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request>& request,
                                  std::shared_ptr<std_srvs::srv::SetBool::Response>& response);
+  
+  void handleChangeStateRequest(
+      const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request> request,
+      std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response> response);  
 
   void publishPointCloud(const std::shared_ptr<ob::FrameSet>& frame_set);
 

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -316,7 +316,10 @@ class OBCameraNode {
                          std::shared_ptr<SetFilter ::Response>& response);
   void setSYNCHostimeCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request>& request,
                               std::shared_ptr<std_srvs::srv::SetBool::Response>& response);
-
+    // Lifecycle Service
+  void handleChangeStateRequest(
+      const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request> request,
+      std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response> response);  
   void resetCaptureServiceVariables();
   void sendSoftwareTriggerCallback(const std::shared_ptr<CameraTrigger::Request>& request,
                                    std::shared_ptr<CameraTrigger::Response>& response);
@@ -411,11 +414,6 @@ class OBCameraNode {
   void setDepthAutoExposureROI();
 
   void setDisparitySearchOffset();
-
-  // Lifecycle Service
-  void handleChangeStateRequest(
-      const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request> request,
-      std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response> response);  
 
  private:
   rclcpp::Node* node_ = nullptr;

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node_driver.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node_driver.h
@@ -118,6 +118,6 @@ class OBCameraNodeDriver : public rclcpp::Node {
   std::string extension_path_;
   static backward::SignalHandling sh;  // for stack trace
   std::string upgrade_firmware_;
-  bool enable_streams_by_default_ {true};
+  bool enable_streams_on_startup_ {true};
 };
 }  // namespace orbbec_camera

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node_driver.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node_driver.h
@@ -118,5 +118,6 @@ class OBCameraNodeDriver : public rclcpp::Node {
   std::string extension_path_;
   static backward::SignalHandling sh;  // for stack trace
   std::string upgrade_firmware_;
+  bool enable_streams_by_default_ {true};
 };
 }  // namespace orbbec_camera

--- a/orbbec_camera/package.xml
+++ b/orbbec_camera/package.xml
@@ -17,6 +17,7 @@
   <depend>rclcpp_components</depend>
   <depend>cv_bridge</depend>
   <depend>camera_info_manager</depend>
+  <depend>lifecycle_msgs</depend>
   <depend>orbbec_camera_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>rclcpp</depend>

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -1387,6 +1387,7 @@ void OBCameraNode::stopStreams() {
         TRY_TO_SET_PROPERTY(setBoolProperty, OB_PROP_FRAME_INTERLEAVE_ENABLE_BOOL,
                             interleave_frame_enable_);
       }
+      pipeline_started_.store(false);
     }
   } catch (const ob::Error &e) {
     RCLCPP_ERROR_STREAM(logger_, "Failed to stop pipeline: " << e.getMessage());

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -163,6 +163,7 @@ void OBCameraNodeDriver::init() {
   net_device_ip_ = declare_parameter<std::string>("net_device_ip", "");
   net_device_port_ = static_cast<int>(declare_parameter<int>("net_device_port", 0));
   enumerate_net_device_ = declare_parameter<bool>("enumerate_net_device", false);
+  enable_streams_by_default_ = declare_parameter<bool>("enable_streams_by_default", true);
   uvc_backend_ = declare_parameter<std::string>("uvc_backend", "libuvc");
   if (uvc_backend_ == "libuvc") {
     ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_LIBUVC);
@@ -505,8 +506,9 @@ void OBCameraNodeDriver::initializeDevice(const std::shared_ptr<ob::Device> &dev
   }
   if (ob_camera_node_) {
     ob_camera_node_->startIMU();
-    // Start Streams Function call is removed from here and added to handleChangeStateRequest
-    // to set up lifecycle management
+    if (enable_streams_by_default_) {
+      ob_camera_node_->enableStreamsByDefault();
+    }
   } else {
     RCLCPP_INFO_STREAM(logger_, "ob_camera_node_ is nullptr");
   }

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -163,7 +163,7 @@ void OBCameraNodeDriver::init() {
   net_device_ip_ = declare_parameter<std::string>("net_device_ip", "");
   net_device_port_ = static_cast<int>(declare_parameter<int>("net_device_port", 0));
   enumerate_net_device_ = declare_parameter<bool>("enumerate_net_device", false);
-  enable_streams_by_default_ = declare_parameter<bool>("enable_streams_by_default", true);
+  enable_streams_on_startup_ = declare_parameter<bool>("enable_streams_on_startup", true);
   uvc_backend_ = declare_parameter<std::string>("uvc_backend", "libuvc");
   if (uvc_backend_ == "libuvc") {
     ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_LIBUVC);
@@ -506,7 +506,7 @@ void OBCameraNodeDriver::initializeDevice(const std::shared_ptr<ob::Device> &dev
   }
   if (ob_camera_node_) {
     ob_camera_node_->startIMU();
-    if (enable_streams_by_default_) {
+    if (enable_streams_on_startup_) {
       ob_camera_node_->startStreams();
     }
   } else {

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -507,7 +507,7 @@ void OBCameraNodeDriver::initializeDevice(const std::shared_ptr<ob::Device> &dev
   if (ob_camera_node_) {
     ob_camera_node_->startIMU();
     if (enable_streams_by_default_) {
-      ob_camera_node_->enableStreamsByDefault();
+      ob_camera_node_->startStreams()
     }
   } else {
     RCLCPP_INFO_STREAM(logger_, "ob_camera_node_ is nullptr");

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -505,7 +505,8 @@ void OBCameraNodeDriver::initializeDevice(const std::shared_ptr<ob::Device> &dev
   }
   if (ob_camera_node_) {
     ob_camera_node_->startIMU();
-    ob_camera_node_->startStreams();
+    // Start Streams Function call is removed from here and added to handleChangeStateRequest
+    // to set up lifecycle management
   } else {
     RCLCPP_INFO_STREAM(logger_, "ob_camera_node_ is nullptr");
   }

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -507,7 +507,7 @@ void OBCameraNodeDriver::initializeDevice(const std::shared_ptr<ob::Device> &dev
   if (ob_camera_node_) {
     ob_camera_node_->startIMU();
     if (enable_streams_by_default_) {
-      ob_camera_node_->startStreams()
+      ob_camera_node_->startStreams();
     }
   } else {
     RCLCPP_INFO_STREAM(logger_, "ob_camera_node_ is nullptr");

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1075,11 +1075,11 @@ void OBCameraNode::resetCaptureServiceVariables() {
 }
 
 void OBCameraNode::handleChangeStateRequest(
-    const std::shared_ptr<ChangeState::Request>& request,
-    std::shared_ptr<ChangeState::Response>& response) {
+    const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request>& request,
+    std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response>& response) {
     
   RCLCPP_INFO_STREAM(logger_, "Received request to change state '%d' with label '%s'",
-                     request->state, request->label.c_str());
+                     request->transition.id, request->transition.label.c_str());
   
   respone->success = true;
   if(request->transition.id == lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE) {

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1113,7 +1113,6 @@ void OBCameraNode::handleChangeStateRequest(
     }
     try {
       stopStreams();
-      response->message = "Camera streams are now OFF";
       RCLCPP_INFO_STREAM(logger_, "Camera streams are now OFF");
     } catch (const ob::Error& e) {
       response->success = false;

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1084,7 +1084,7 @@ void OBCameraNode::handleChangeStateRequest(
   response->success = true;
   if(request->transition.id == lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE) {
     RCLCPP_INFO_STREAM(logger_, "Recieved request to turn ON camera streams");
-    if (pipeline_ || pipeline_started_){
+    if (pipeline_started_){
       RCLCPP_WARN_STREAM(logger_, "Camera streams already ON");
       response->success = false;
       return;

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1078,7 +1078,7 @@ void OBCameraNode::handleChangeStateRequest(
     const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request>& request,
     std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response>& response) {
     
-  RCLCPP_INFO_STREAM(logger_, "Received request to change state '%d' with label '%s'",
+  RCLCPP_INFO(logger_, "Received request to change state '%d' with label '%s'",
                      request->transition.id, request->transition.label.c_str());
   
   respone->success = true;

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1084,7 +1084,7 @@ void OBCameraNode::handleChangeStateRequest(
     RCLCPP_INFO_STREAM(logger_, "Recieved request to turn ON camera streams");
     if (pipeline_started_){
       RCLCPP_WARN_STREAM(logger_, "Camera streams already ON");
-      response->success = false;
+      response->success = true;
       return;
     }
     try {
@@ -1106,7 +1106,7 @@ void OBCameraNode::handleChangeStateRequest(
     RCLCPP_INFO_STREAM(logger_, "Recieved request to turn OFF camera streams");
     if (!pipeline_ || !pipeline_started_){
       RCLCPP_WARN_STREAM(logger_, "Camera streams already OFF");
-      response->success = false;
+      response->success = true;
       return;
     }
     try {

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -223,8 +223,7 @@ void OBCameraNode::setupCameraCtrlServices() {
       });
   change_state_srv_ = node_->create_service<lifecycle_msgs::srv::ChangeState>(
       "change_state", std::bind(&OBCameraNode::handleChangeStateRequest, this,
-                                std::placeholders::_1, std::placeholders::_2),
-      rclcpp::QoS(1), services_callback_group_);
+                                std::placeholders::_1, std::placeholders::_2));
 }
 
 void OBCameraNode::setExposureCallback(const std::shared_ptr<SetInt32::Request>& request,

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1075,8 +1075,8 @@ void OBCameraNode::resetCaptureServiceVariables() {
 }
 
 void OBCameraNode::handleChangeStateRequest(
-    const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request>& request,
-    std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response>& response) {
+    const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request> request,
+        std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response> response) {
     
   RCLCPP_INFO(logger_, "Received request to change state '%d' with label '%s'",
                      request->transition.id, request->transition.label.c_str());

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1087,25 +1087,20 @@ void OBCameraNode::handleChangeStateRequest(
     if (pipeline_ || pipeline_started_){
       RCLCPP_WARN_STREAM(logger_, "Camera streams already ON");
       response->success = false;
-      response->message = "Camera streams already ON";
       return;
     }
     try {
       setupProfiles();
       startStreams();
-      response->message = "Camera streams are now ON";
       RCLCPP_INFO_STREAM(logger_, "Camera streams are now ON");
     } catch (const ob::Error& e) {
       response->success = false;
-      response->message = "Failed to start camera streams: " + std::string(e.getMessage());
       RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: " << e.getMessage());
     } catch (const std::exception& e) {
       response->success = false;
-      response->message = "Failed to start camera streams: " + std::string(e.what());
       RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: " << e.what());
     } catch (...) {
       response->success = false;
-      response->message = "Failed to start camera streams: Unknown Error";
       RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: Unknown Error");
     }
   }
@@ -1114,7 +1109,6 @@ void OBCameraNode::handleChangeStateRequest(
     if (!pipeline_ || !pipeline_started_){
       RCLCPP_WARN_STREAM(logger_, "Camera streams already OFF");
       response->success = false;
-      response->message = "Camera streams already OFF";
       return;
     }
     try {
@@ -1123,21 +1117,17 @@ void OBCameraNode::handleChangeStateRequest(
       RCLCPP_INFO_STREAM(logger_, "Camera streams are now OFF");
     } catch (const ob::Error& e) {
       response->success = false;
-      response->message = "Failed to stop camera streams: " + std::string(e.getMessage());
       RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.getMessage());
     } catch (const std::exception& e) {
       response->success = false;
-      response->message = "Failed to stop camera streams: " + std::string(e.what());
       RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.what());
     } catch (...) {
       response->success = false;
-      response->message = "Failed to stop camera streams: Unknown Error";
       RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: Unknown Error");
     }
   }
   else {
     response->success = false;
-    response->message = "Unsupported transition ID: " + std::to_string(request->transition.id);
     RCLCPP_ERROR_STREAM(logger_, "Unsupported transition ID: " << request->transition.id);
   }
 

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1081,7 +1081,7 @@ void OBCameraNode::handleChangeStateRequest(
   RCLCPP_INFO(logger_, "Received request to change state '%d' with label '%s'",
                      request->transition.id, request->transition.label.c_str());
   
-  respone->success = true;
+  response->success = true;
   if(request->transition.id == lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE) {
     RCLCPP_INFO_STREAM(logger_, "Recieved request to turn ON camera streams");
     if (pipeline_ || pipeline_started_){

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1129,7 +1129,6 @@ void OBCameraNode::handleChangeStateRequest(
     response->success = false;
     RCLCPP_ERROR_STREAM(logger_, "Unsupported transition ID: " << request->transition.id);
   }
-
 }
 
 void OBCameraNode::sendSoftwareTriggerCallback(

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -222,10 +222,9 @@ void OBCameraNode::setupCameraCtrlServices() {
         setReadCustomerData(request, response);
       });
   change_state_srv_ = node_->create_service<lifecycle_msgs::srv::ChangeState>(
-      "change_state", [this](const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request> request,
-                             std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response> response) {
-        handleChangeStateRequest(request, response);
-      });
+      "change_state", std::bind(&OBCameraNode::handleChangeStateRequest, this,
+                                std::placeholders::_1, std::placeholders::_2),
+      rclcpp::QoS(1), services_callback_group_);
 }
 
 void OBCameraNode::setExposureCallback(const std::shared_ptr<SetInt32::Request>& request,


### PR DESCRIPTION
This PR adds a lifecycle service in order to disable/enable the pipeline to stream from the device. 

This was tested by checking the output of `iftop` when the stream was enabled and then disabled. This was also tested with a script to disable the pipeline, wait 5 seconds, re-enable the pipeline, wait 5 seconds, and then check if images were being published to the raw image topic. The script checked this several hundred times and the camera seemed to behave as expected.

In the screenshots below, the camera tested has the addres 192.168.1.10

Iftop with the right camera enabled

<img width="1616" height="405" alt="image" src="https://github.com/user-attachments/assets/36943510-947a-4e46-9c4a-1f7bf9a97e56" />

Iftop with the right camera disabled

<img width="1616" height="405" alt="image" src="https://github.com/user-attachments/assets/a1cb66ca-dc32-408a-aa19-0b11c2df9640" />
