### PR TITLE
APG-2108 Adds a status topic to the camera driver

### DIFF
--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -38,6 +38,7 @@
 #include <std_srvs/srv/empty.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <lifecycle_msgs/srv/change_state.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
 
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <camera_info_manager/camera_info_manager.hpp>
@@ -482,6 +483,8 @@ class OBCameraNode {
 
   bool isWriteCustomerDataSuccess() const;
 
+  void change_state(uint8 state);
+
  private:
   std::atomic_bool write_customer_data_success_{false};
   std::atomic_bool user_calibration_ready_{false};
@@ -860,5 +863,6 @@ class OBCameraNode {
   std::unique_ptr<FpsDelayStatus> fps_delay_status_depth_{nullptr};
 
   std::string intra_camera_sync_reference_;
+  rclcpp::Publisher<lifecycle_msgs::msg::State>::SharedPtr lifecycle_state_pub_;
 };
 }  // namespace orbbec_camera

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -483,7 +483,7 @@ class OBCameraNode {
 
   bool isWriteCustomerDataSuccess() const;
 
-  void change_state(uint8_t state);
+  void set_state(uint8_t state);
 
  private:
   std::atomic_bool write_customer_data_success_{false};

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -483,7 +483,7 @@ class OBCameraNode {
 
   bool isWriteCustomerDataSuccess() const;
 
-  void change_state(uint8 state);
+  void change_state(uint8_t state);
 
  private:
   std::atomic_bool write_customer_data_success_{false};

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2378,7 +2378,8 @@ void OBCameraNode::setupPublishers() {
   // Similar to a latched topic
   rclcpp::QoS lifecycle_qos(rclcpp::KeepLast(1));
   lifecycle_qos.transient_local().reliable(); 
-  lifecycle_state_pub_ =  node_->create_publisher<lifecycle_msgs::msg::State>("state", lifecycle_qos);
+  lifecycle_state_pub_ =
+    node_->create_publisher<lifecycle_msgs::msg::State>(topic_prefix + "state", lifecycle_qos);
 }
 
 void OBCameraNode::set_state(uint8_t state) {

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2381,7 +2381,7 @@ void OBCameraNode::setupPublishers() {
   lifecycle_state_pub_ =  node_->create_publisher<lifecycle_msgs::msg::State>("state", lifecycle_qos)
 }
 
-void set_state(uint8 state) {
+void OBCameraNode::set_state(uint8 state) {
   lifecycle_msgs::msg::State msg;
   msg.id = state;
   lifecycle_state_pub_->publish(msg);

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -1527,7 +1527,6 @@ void OBCameraNode::stopStreams() {
 
   if (!pipeline_started_ || !pipeline_) {
     RCLCPP_INFO_STREAM(logger_, "pipeline not started or not exist, skip stop pipeline");
-    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
     return;
   }
 

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -95,7 +95,7 @@ OBCameraNode::OBCameraNode(rclcpp::Node *node, std::shared_ptr<ob::Device> devic
   fps_delay_status_color_ = std::make_unique<FpsDelayStatus>(logger_);
   fps_delay_status_depth_ = std::make_unique<FpsDelayStatus>(logger_);
   // Set the Lifecycle state to unconfigured to begin with.
-  set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNCONFIGURED);
+  set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
 }
 
 template <class T>
@@ -1384,7 +1384,7 @@ int OBCameraNode::init_interleave_laser_param() {
 void OBCameraNode::startStreams() {
   if (pipeline_ != nullptr) {
     pipeline_.reset();
-    set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
+    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
   }
   pipeline_ = std::make_unique<ob::Pipeline>(device_);
 
@@ -1448,7 +1448,7 @@ void OBCameraNode::startStreams() {
     RCLCPP_INFO_STREAM(logger_, "Setting OB_PROP_FRAME_INTERLEAVE_LASER_PATTERN_SYNC_DELAY_INT 0 ");
   }
   pipeline_started_.store(true);
-  set_state(lifecycle_msgs::msg::PRIMARY_STATE_ACTIVE);
+  set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 }
 
 void OBCameraNode::startIMUSyncStream() {
@@ -1527,7 +1527,7 @@ void OBCameraNode::stopStreams() {
 
   if (!pipeline_started_ || !pipeline_) {
     RCLCPP_INFO_STREAM(logger_, "pipeline not started or not exist, skip stop pipeline");
-    set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
+    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
     return;
   }
 
@@ -1572,17 +1572,17 @@ void OBCameraNode::stopStreams() {
         }
       }
       pipeline_started_.store(false);
-      set_state(lifecycle_msgs::msg::PRIMARY_STATE_INACTIVE);
+      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
     } else {
       RCLCPP_WARN_STREAM(logger_,
                          "Device or pipeline not available during stop - likely disconnected");
     }
   } catch (const ob::Error &e) {
     RCLCPP_ERROR_STREAM(logger_, "Failed to stop pipeline: " << e.getMessage());
-    set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
+    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
   } catch (...) {
     RCLCPP_ERROR_STREAM(logger_, "Failed to stop pipeline");
-    set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
+    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
   }
 }
 
@@ -2378,7 +2378,7 @@ void OBCameraNode::setupPublishers() {
   // Similar to a latched topic
   rclcpp::QoS lifecycle_qos(rclcpp::KeepLast(1));
   lifecycle_qos.transient_local().reliable(); 
-  lifecycle_state_pub_ =  node_->create_publisher<lifecycle_msgs::msg::State>("state", lifecycle_qos)
+  lifecycle_state_pub_ =  node_->create_publisher<lifecycle_msgs::msg::State>("state", lifecycle_qos);
 }
 
 void OBCameraNode::set_state(uint8_t state) {

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -94,6 +94,8 @@ OBCameraNode::OBCameraNode(rclcpp::Node *node, std::shared_ptr<ob::Device> devic
 
   fps_delay_status_color_ = std::make_unique<FpsDelayStatus>(logger_);
   fps_delay_status_depth_ = std::make_unique<FpsDelayStatus>(logger_);
+  // Set the Lifecycle state to unconfigured to begin with.
+  set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNCONFIGURED);
 }
 
 template <class T>
@@ -1382,6 +1384,7 @@ int OBCameraNode::init_interleave_laser_param() {
 void OBCameraNode::startStreams() {
   if (pipeline_ != nullptr) {
     pipeline_.reset();
+    set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
   }
   pipeline_ = std::make_unique<ob::Pipeline>(device_);
 
@@ -1445,6 +1448,7 @@ void OBCameraNode::startStreams() {
     RCLCPP_INFO_STREAM(logger_, "Setting OB_PROP_FRAME_INTERLEAVE_LASER_PATTERN_SYNC_DELAY_INT 0 ");
   }
   pipeline_started_.store(true);
+  set_state(lifecycle_msgs::msg::PRIMARY_STATE_ACTIVE);
 }
 
 void OBCameraNode::startIMUSyncStream() {
@@ -1523,6 +1527,7 @@ void OBCameraNode::stopStreams() {
 
   if (!pipeline_started_ || !pipeline_) {
     RCLCPP_INFO_STREAM(logger_, "pipeline not started or not exist, skip stop pipeline");
+    set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
     return;
   }
 
@@ -1567,14 +1572,17 @@ void OBCameraNode::stopStreams() {
         }
       }
       pipeline_started_.store(false);
+      set_state(lifecycle_msgs::msg::PRIMARY_STATE_INACTIVE);
     } else {
       RCLCPP_WARN_STREAM(logger_,
                          "Device or pipeline not available during stop - likely disconnected");
     }
   } catch (const ob::Error &e) {
     RCLCPP_ERROR_STREAM(logger_, "Failed to stop pipeline: " << e.getMessage());
+    set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
   } catch (...) {
     RCLCPP_ERROR_STREAM(logger_, "Failed to stop pipeline");
+    set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
   }
 }
 
@@ -2366,6 +2374,17 @@ void OBCameraNode::setupPublishers() {
   std_msgs::msg::String msg;
   msg.data = filter_status_.dump(2);
   filter_status_pub_->publish(msg);
+
+  // Similar to a latched topic
+  rclcpp::QoS lifecycle_qos(rclcpp::KeepLast(1));
+  lifecycle_qos.transient_local().reliable(); 
+  lifecycle_state_pub_ =  node_->create_publisher<lifecycle_msgs::msg::State>("state", lifecycle_qos)
+}
+
+void set_state(uint8 state) {
+  lifecycle_msgs::msg::State msg;
+  msg.id = state;
+  lifecycle_state_pub_->publish(msg);
 }
 
 void OBCameraNode::publishPointCloud(const std::shared_ptr<ob::FrameSet> &frame_set) {

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2381,7 +2381,7 @@ void OBCameraNode::setupPublishers() {
   lifecycle_state_pub_ =  node_->create_publisher<lifecycle_msgs::msg::State>("state", lifecycle_qos)
 }
 
-void OBCameraNode::set_state(uint8 state) {
+void OBCameraNode::set_state(uint8_t state) {
   lifecycle_msgs::msg::State msg;
   msg.id = state;
   lifecycle_state_pub_->publish(msg);

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1212,12 +1212,15 @@ void OBCameraNode::handleChangeStateRequest(
     } catch (const ob::Error& e) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: " << e.getMessage());
+      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
     } catch (const std::exception& e) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: " << e.what());
+      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
     } catch (...) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: Unknown Error");
+      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
     }
   }
   else if(request->transition.id == lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE) {
@@ -1230,15 +1233,19 @@ void OBCameraNode::handleChangeStateRequest(
     try {
       stopStreams();
       RCLCPP_INFO_STREAM(logger_, "Camera streams are now OFF");
+      set_state(lifecycle_msgs::msg::PRIMARY_STATE_INACTIVE);
     } catch (const ob::Error& e) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.getMessage());
+      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
     } catch (const std::exception& e) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.what());
+      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
     } catch (...) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: Unknown Error");
+      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
     }
   }
   else {

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1212,15 +1212,15 @@ void OBCameraNode::handleChangeStateRequest(
     } catch (const ob::Error& e) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: " << e.getMessage());
-      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
+      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
     } catch (const std::exception& e) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: " << e.what());
-      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
+      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
     } catch (...) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: Unknown Error");
-      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
+      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
     }
   }
   else if(request->transition.id == lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE) {
@@ -1233,19 +1233,19 @@ void OBCameraNode::handleChangeStateRequest(
     try {
       stopStreams();
       RCLCPP_INFO_STREAM(logger_, "Camera streams are now OFF");
-      set_state(lifecycle_msgs::msg::PRIMARY_STATE_INACTIVE);
+      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
     } catch (const ob::Error& e) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.getMessage());
-      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
+      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
     } catch (const std::exception& e) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.what());
-      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
+      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
     } catch (...) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: Unknown Error");
-      set_state(lifecycle_msgs::msg::PRIMARY_STATE_UNKNOWN);
+      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
     }
   }
   else {

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1233,7 +1233,6 @@ void OBCameraNode::handleChangeStateRequest(
     try {
       stopStreams();
       RCLCPP_INFO_STREAM(logger_, "Camera streams are now OFF");
-      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
     } catch (const ob::Error& e) {
       response->success = false;
       RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.getMessage());


### PR DESCRIPTION
This change introduces a /state topic that uses the lifecycle message types to indicate what state the camera is in (streaming or not).

Tested on roadkill.