### PR TITLE
APG-2180 Adds functions to recover after a trigger service stalls

### DIFF
--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -129,6 +129,7 @@ set(SOURCE_FILES
     src/ros_param_backend.cpp
     src/ros_service.cpp
     src/synced_imu_publisher.cpp
+    src/trigger_failure_monitor.cpp
     src/utils.cpp
     src/jpeg_decoder.cpp
 )

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -413,6 +413,8 @@ class OBCameraNode {
 
   bool deactivateStreams();
 
+  void setupTriggerFailureMonitor();
+
   void publishPointCloud(const std::shared_ptr<ob::FrameSet>& frame_set);
 
   void publishDepthPointCloud(const std::shared_ptr<ob::FrameSet>& frame_set);

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -406,7 +406,11 @@ class OBCameraNode {
   
   void handleChangeStateRequest(
       const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request> request,
-      std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response> response);  
+      std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response> response);
+
+  bool activateStreams();
+
+  bool deactivateStreams();
 
   void publishPointCloud(const std::shared_ptr<ob::FrameSet>& frame_set);
 
@@ -805,6 +809,7 @@ class OBCameraNode {
   // soft ware trigger
   rclcpp::TimerBase::SharedPtr software_trigger_timer_;
   rclcpp::TimerBase::SharedPtr diagnostic_timer_;
+  rclcpp::TimerBase::SharedPtr trigger_failure_monitor_timer_;
   std::chrono::milliseconds software_trigger_period_{33};
   bool enable_heartbeat_ = false;
   bool enable_color_undistortion_ = false;
@@ -866,5 +871,12 @@ class OBCameraNode {
 
   std::string intra_camera_sync_reference_;
   rclcpp::Publisher<lifecycle_msgs::msg::State>::SharedPtr lifecycle_state_pub_;
+
+  // software trigger failure monitor + recovery
+  bool enable_trigger_failure_monitor_{false}
+  int consecutive_trigger_failures_{0};
+  int trigger_failures_before_recovery_{2};
+  double trigger_failure_monitor_timer_period_{1.0};  // seconds
+
 };
 }  // namespace orbbec_camera

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -70,6 +70,7 @@
 #include "orbbec_camera/image_publisher.h"
 #include "orbbec_camera/fps_counter.hpp"
 #include "orbbec_camera/fps_delay_status.hpp"
+#include "orbbec_camera/trigger_failure_monitor.h"
 #include "jpeg_decoder.h"
 #include <std_msgs/msg/string.hpp>
 #include <fcntl.h>
@@ -411,10 +412,6 @@ class OBCameraNode {
   bool activateStreams();
 
   bool deactivateStreams();
-
-  void setupTriggerFailureMonitor();
-
-  void triggerFailureMonitorTimerCallback();
 
   void publishPointCloud(const std::shared_ptr<ob::FrameSet>& frame_set);
 
@@ -813,7 +810,6 @@ class OBCameraNode {
   // soft ware trigger
   rclcpp::TimerBase::SharedPtr software_trigger_timer_;
   rclcpp::TimerBase::SharedPtr diagnostic_timer_;
-  rclcpp::TimerBase::SharedPtr trigger_failure_monitor_timer_;
   std::chrono::milliseconds software_trigger_period_{33};
   bool enable_heartbeat_ = false;
   bool enable_color_undistortion_ = false;
@@ -876,11 +872,7 @@ class OBCameraNode {
   std::string intra_camera_sync_reference_;
   rclcpp::Publisher<lifecycle_msgs::msg::State>::SharedPtr lifecycle_state_pub_;
 
-  // software trigger failure monitor + recovery
-  bool enable_trigger_failure_monitor_{false};
-  int consecutive_trigger_failures_{0};
-  int trigger_failures_before_recovery_{2};
-  double trigger_failure_monitor_timer_period_{1.0};  // seconds
-
+  // Trigger failure monitor for automatic recovery
+  std::unique_ptr<TriggerFailureMonitor> trigger_failure_monitor_;
 };
 }  // namespace orbbec_camera

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -873,7 +873,7 @@ class OBCameraNode {
   rclcpp::Publisher<lifecycle_msgs::msg::State>::SharedPtr lifecycle_state_pub_;
 
   // software trigger failure monitor + recovery
-  bool enable_trigger_failure_monitor_{false}
+  bool enable_trigger_failure_monitor_{false};
   int consecutive_trigger_failures_{0};
   int trigger_failures_before_recovery_{2};
   double trigger_failure_monitor_timer_period_{1.0};  // seconds

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -412,6 +412,10 @@ class OBCameraNode {
 
   bool deactivateStreams();
 
+  void setupTriggerFailureMonitor();
+
+  void triggerFailureMonitorTimerCallback();
+
   void publishPointCloud(const std::shared_ptr<ob::FrameSet>& frame_set);
 
   void publishDepthPointCloud(const std::shared_ptr<ob::FrameSet>& frame_set);

--- a/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
+++ b/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
@@ -1,0 +1,102 @@
+#include <rclcpp/rclcpp.hpp>
+#include <functional>
+#include <atomic>
+#include <memory>
+#include <chrono>
+
+namespace orbbec_camera {
+
+/**
+ * @brief Monitors trigger failures and cycles the streams to recover
+ */
+class TriggerFailureMonitor {
+ public:
+  /**
+   * @brief Callback type for stream activation/deactivation
+   * @return true if operation succeeded, false otherwise
+   */
+  using StreamControlCallback = std::function<bool()>;
+
+  /**
+   * @brief Callback type to check if pipeline is running
+   * @return true if pipeline is started, false otherwise
+   */
+  using PipelineStatusCallback = std::function<bool()>;
+
+  /**
+   * @brief Constructor
+   * @param node ROS node for creating timer
+   * @param logger Logger for diagnostic messages
+   */
+  TriggerFailureMonitor(rclcpp::Node* node,
+                        const rclcpp::Logger& logger);
+
+  /**
+   * @brief Destructor - cleans up timer
+   */
+  ~TriggerFailureMonitor();
+
+  /**
+   * @brief Set callback for deactivating streams
+   * @param callback Function to call to deactivate streams
+   */
+  void setDeactivateCallback(StreamControlCallback callback);
+
+  /**
+   * @brief Set callback for activating streams
+   * @param callback Function to call to activate streams
+   */
+  void setActivateCallback(StreamControlCallback callback);
+
+  /**
+   * @brief Set callback to check pipeline status
+   * @param callback Function to call to check if pipeline is running
+   */
+  void setPipelineStatusCallback(PipelineStatusCallback callback);
+
+  /**
+   * @brief Record a trigger failure
+   * 
+   * Increments the consecutive failure count. Recovery will be triggered
+   * by the monitor timer when threshold is exceeded.
+   */
+  void recordFailure();
+
+  /**
+   * @brief Record a successful trigger
+   * 
+   * Resets the consecutive failure count to zero.
+   */
+  void recordSuccess();
+
+  /**
+   * @brief Cleanup and stop monitoring
+   */
+  void cleanup();
+
+ private:
+  /**
+   * @brief Timer callback to check for failures and trigger recovery
+   */
+  void timerCallback();
+
+  /**
+   * @brief Perform stream recovery (deactivate, wait, activate)
+   * @return true if recovery succeeded, false otherwise
+   */
+  bool cycleStreams();
+
+  rclcpp::Node* node_;                              
+  rclcpp::Logger logger_;                           
+  
+  rclcpp::TimerBase::SharedPtr timer_;              
+  int consecutive_failures_{0};    
+  
+  StreamControlCallback deactivate_callback_;       
+  StreamControlCallback activate_callback_;         
+  PipelineStatusCallback pipeline_status_callback_; 
+  int failures_before_recovery_{2};
+  double timer_period_seconds_{1.0}; 
+};
+
+}  // namespace orbbec_camera

--- a/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
+++ b/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
@@ -27,9 +27,13 @@ class TriggerFailureMonitor {
    * @brief Constructor
    * @param node ROS node for creating timer
    * @param logger Logger for diagnostic messages
+   * @param failures_before_recovery Number of failures before recovery
+   * @param timer_period_seconds Timer period in seconds
    */
   TriggerFailureMonitor(rclcpp::Node* node,
-                        const rclcpp::Logger& logger);
+                        const rclcpp::Logger& logger,
+                        int failures_before_recovery,
+                        double timer_period_seconds);
 
   /**
    * @brief Destructor - cleans up timer

--- a/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
+++ b/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
@@ -78,6 +78,11 @@ class TriggerFailureMonitor {
    */
   void cleanup();
 
+  /**
+   * @brief Flag indicating if recovery is in progress
+   */
+  bool isRecoveryInProgress() const;
+
  private:
   /**
    * @brief Timer callback to check for failures and trigger recovery
@@ -101,6 +106,7 @@ class TriggerFailureMonitor {
   PipelineStatusCallback pipeline_status_callback_; 
   int failures_before_recovery_{2};
   double timer_period_seconds_{1.0}; 
+  bool recovery_in_progress_{false};
 };
 
 }  // namespace orbbec_camera

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2160,13 +2160,17 @@ bool OBCameraNode::deactivateStreams() {
 void OBCameraNode::setupTriggerFailureMonitor() {
   // Default trigger failure monitor to be enabled if service trigger is enabled
   bool enabled;
+  int failures_before_recovery;
+  double timer_period_seconds;
   setAndGetNodeParameter<bool>(enabled, "enable_trigger_failure_monitor", service_trigger_enabled_);
+  setAndGetNodeParameter<int>(failures_before_recovery, "trigger_failures_before_recovery", 2);
+  setAndGetNodeParameter<double>(timer_period_seconds, "trigger_failure_monitor_timer_period", 1.0);
   if (!enabled) {
     RCLCPP_INFO_STREAM(logger_, "Trigger failure monitor is disabled");
     return;
   }
   trigger_failure_monitor_ = std::make_unique<TriggerFailureMonitor>(
-      node_, logger_);
+      node_, logger_, failures_before_recovery, timer_period_seconds);
   // Set up callbacks for stream control and pipeline status
   trigger_failure_monitor_->setActivateCallback(
       std::bind(&OBCameraNode::activateStreams, this));

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2187,6 +2187,7 @@ void OBCameraNode::triggerFailureMonitorTimerCallback() {
       RCLCPP_ERROR(logger_, "Failed to deactivate streams during trigger failure recovery");
       return;
     }
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
     bool activate_success = activateStreams();
     if (!activate_success) {
       RCLCPP_ERROR(logger_, "Failed to reactivate streams during trigger failure recovery");

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -157,6 +157,10 @@ void OBCameraNode::clean() noexcept {
     if (diagnostic_updater_) {
       diagnostic_updater_.reset();
     }
+    if (trigger_failure_monitor_timer_) {
+      trigger_failure_monitor_timer_->cancel();
+      trigger_failure_monitor_timer_.reset();
+    }
   } catch (...) {
     // Ignore exceptions during diagnostic cleanup
   }
@@ -1864,6 +1868,11 @@ void OBCameraNode::getParameters() {
   setAndGetNodeParameter<bool>(trigger_out_enabled_, "trigger_out_enabled", true);
   setAndGetNodeParameter<bool>(software_trigger_enabled_, "software_trigger_enabled", false);
   setAndGetNodeParameter<bool>(service_trigger_enabled_, "service_trigger_enabled", false);
+  setAndGetNodeParameter<bool>(enable_trigger_failure_monitor_,
+                               "enable_trigger_failure_monitor", service_trigger_enabled_);
+  setAndGetNodeParameter<int>(trigger_failures_before_recovery_, "trigger_failures_before_recovery", 2);
+  setAndGetNodeParameter<double>(trigger_failure_monitor_timer_period_,
+                                 "trigger_failure_monitor_timer_period", 1.0);
   setAndGetNodeParameter<bool>(enable_ptp_config_, "enable_ptp_config", false);
   setAndGetNodeParameter<std::string>(cloud_frame_id_, "cloud_frame_id", "");
   if (enable_colored_point_cloud_ || enable_d2c_viewer_) {
@@ -2038,6 +2047,7 @@ void OBCameraNode::setupTopics() {
     setupCameraCtrlServices();
     setupPublishers();
     setupDiagnosticUpdater();
+    setupTriggerFailureMonitor();
   } catch (const ob::Error &e) {
     RCLCPP_ERROR_STREAM(logger_, "Failed to setup topics: " << e.getMessage());
     throw std::runtime_error(e.getMessage());
@@ -2108,6 +2118,80 @@ void OBCameraNode::onTemperatureUpdate(diagnostic_updater::DiagnosticStatusWrapp
   } catch (...) {
     RCLCPP_ERROR(logger_, "Failed to TemperatureUpdate3: Device is deactivated/disconnected!");
     status.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Unknown error");
+  }
+}
+
+bool OBCameraNode::activateStreams() {
+  try {
+    setupProfiles();
+    startStreams();
+    RCLCPP_INFO_STREAM(logger_, "Camera streams are now ON");
+    return true;
+  } catch (const ob::Error& e) {
+    RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: " << e.getMessage());
+    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
+    return false;
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: " << e.what());
+    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
+    return false;
+  } catch (...) {
+    RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: Unknown Error");
+    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
+    return false;
+  }
+}
+
+bool OBCameraNode::deactivateStreams() {
+  try {
+    stopStreams();
+    RCLCPP_INFO_STREAM(logger_, "Camera streams are now OFF");
+    return true;
+  } catch (const ob::Error& e) {
+    RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.getMessage());
+    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
+    return false;
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.what());
+    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
+    return false;
+  } catch (...) {
+    RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: Unknown Error");
+    set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
+    return false;
+  }
+}
+
+void OBCameraNode::setupTriggerFailureMonitor() {
+  if (!service_trigger_enabled_ && !software_trigger_enabled_ || !enable_trigger_failure_monitor_) {
+    return;
+  }
+  RCLCPP_INFO_STREAM(logger_, "Setup trigger failure monitor timer with period "
+                                  << trigger_failure_monitor_timer_period_ << " seconds");
+  trigger_failure_monitor_timer_ = node_->create_wall_timer(
+      std::chrono::duration<double>(trigger_failure_monitor_timer_period_), triggerFailureMonitorTimerCallback);
+}
+
+// timer callback to monitor trigger failure
+void OBCameraNode::triggerFailureMonitorTimerCallback() {
+  if (!pipeline_started_.load()) {
+    return;
+  }
+  if (consecutive_trigger_failures_ >= trigger_failures_before_recovery_) {
+    RCLCPP_WARN_STREAM(logger_, "Maximum consecutive trigger failures reached ("
+                                    << consecutive_trigger_failures_
+                                    << "), restarting streams...");
+    bool deactivate_success = deactivateStreams();
+    if (!deactivate_success) {
+      RCLCPP_ERROR(logger_, "Failed to deactivate streams during trigger failure recovery");
+      return;
+    }
+    bool activate_success = activateStreams();
+    if (!activate_success) {
+      RCLCPP_ERROR(logger_, "Failed to reactivate streams during trigger failure recovery");
+      return;
+    }
+    consecutive_trigger_failures_ = 0;
   }
 }
 

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2163,7 +2163,7 @@ bool OBCameraNode::deactivateStreams() {
 }
 
 void OBCameraNode::setupTriggerFailureMonitor() {
-  if (!service_trigger_enabled_ && !software_trigger_enabled_ || !enable_trigger_failure_monitor_) {
+  if ((!service_trigger_enabled_ && !software_trigger_enabled_) || !enable_trigger_failure_monitor_) {
     return;
   }
   RCLCPP_INFO_STREAM(logger_, "Setup trigger failure monitor timer with period "

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -157,9 +157,9 @@ void OBCameraNode::clean() noexcept {
     if (diagnostic_updater_) {
       diagnostic_updater_.reset();
     }
-    if (trigger_failure_monitor_timer_) {
-      trigger_failure_monitor_timer_->cancel();
-      trigger_failure_monitor_timer_.reset();
+    if (trigger_failure_monitor_) {
+      trigger_failure_monitor_->cleanup();
+      trigger_failure_monitor_.reset();
     }
   } catch (...) {
     // Ignore exceptions during diagnostic cleanup
@@ -1868,11 +1868,6 @@ void OBCameraNode::getParameters() {
   setAndGetNodeParameter<bool>(trigger_out_enabled_, "trigger_out_enabled", true);
   setAndGetNodeParameter<bool>(software_trigger_enabled_, "software_trigger_enabled", false);
   setAndGetNodeParameter<bool>(service_trigger_enabled_, "service_trigger_enabled", false);
-  setAndGetNodeParameter<bool>(enable_trigger_failure_monitor_,
-                               "enable_trigger_failure_monitor", service_trigger_enabled_);
-  setAndGetNodeParameter<int>(trigger_failures_before_recovery_, "trigger_failures_before_recovery", 2);
-  setAndGetNodeParameter<double>(trigger_failure_monitor_timer_period_,
-                                 "trigger_failure_monitor_timer_period", 1.0);
   setAndGetNodeParameter<bool>(enable_ptp_config_, "enable_ptp_config", false);
   setAndGetNodeParameter<std::string>(cloud_frame_id_, "cloud_frame_id", "");
   if (enable_colored_point_cloud_ || enable_d2c_viewer_) {
@@ -2163,38 +2158,22 @@ bool OBCameraNode::deactivateStreams() {
 }
 
 void OBCameraNode::setupTriggerFailureMonitor() {
-  if ((!service_trigger_enabled_ && !software_trigger_enabled_) || !enable_trigger_failure_monitor_) {
+  // Default trigger failure monitor to be enabled if service trigger is enabled
+  bool enabled;
+  setAndGetNodeParameter<bool>(enabled, "enable_trigger_failure_monitor", service_trigger_enabled_);
+  if (!enabled) {
+    RCLCPP_INFO_STREAM(logger_, "Trigger failure monitor is disabled");
     return;
   }
-  RCLCPP_INFO_STREAM(logger_, "Setup trigger failure monitor timer with period "
-                                  << trigger_failure_monitor_timer_period_ << " seconds");
-  trigger_failure_monitor_timer_ = node_->create_wall_timer(
-      std::chrono::duration<double>(trigger_failure_monitor_timer_period_),
-      std::bind(&OBCameraNode::triggerFailureMonitorTimerCallback, this));
-}
-
-// timer callback to monitor trigger failure
-void OBCameraNode::triggerFailureMonitorTimerCallback() {
-  if (!pipeline_started_.load()) {
-    return;
-  }
-  if (consecutive_trigger_failures_ >= trigger_failures_before_recovery_) {
-    RCLCPP_WARN_STREAM(logger_, "Maximum consecutive trigger failures reached ("
-                                    << consecutive_trigger_failures_
-                                    << "), restarting streams...");
-    bool deactivate_success = deactivateStreams();
-    if (!deactivate_success) {
-      RCLCPP_ERROR(logger_, "Failed to deactivate streams during trigger failure recovery");
-      return;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(250));
-    bool activate_success = activateStreams();
-    if (!activate_success) {
-      RCLCPP_ERROR(logger_, "Failed to reactivate streams during trigger failure recovery");
-      return;
-    }
-    consecutive_trigger_failures_ = 0;
-  }
+  trigger_failure_monitor_ = std::make_unique<TriggerFailureMonitor>(
+      node_, logger_);
+  // Set up callbacks for stream control and pipeline status
+  trigger_failure_monitor_->setActivateCallback(
+      std::bind(&OBCameraNode::activateStreams, this));
+  trigger_failure_monitor_->setDeactivateCallback(
+      std::bind(&OBCameraNode::deactivateStreams, this));
+  trigger_failure_monitor_->setPipelineStatusCallback(
+      [this]() { return pipeline_started_.load(); });
 }
 
 void OBCameraNode::setupDiagnosticUpdater() {

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2169,7 +2169,8 @@ void OBCameraNode::setupTriggerFailureMonitor() {
   RCLCPP_INFO_STREAM(logger_, "Setup trigger failure monitor timer with period "
                                   << trigger_failure_monitor_timer_period_ << " seconds");
   trigger_failure_monitor_timer_ = node_->create_wall_timer(
-      std::chrono::duration<double>(trigger_failure_monitor_timer_period_), triggerFailureMonitorTimerCallback);
+      std::chrono::duration<double>(trigger_failure_monitor_timer_period_),
+      std::bind(&OBCameraNode::triggerFailureMonitorTimerCallback, this));
 }
 
 // timer callback to monitor trigger failure

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1197,6 +1197,14 @@ void OBCameraNode::handleChangeStateRequest(
   RCLCPP_INFO(logger_, "Received request to change state '%d' with label '%s'",
                      request->transition.id, request->transition.label.c_str());
   
+  if (trigger_failure_monitor_) {
+    bool recovery_in_progress = trigger_failure_monitor_->isRecoveryInProgress();
+    if (recovery_in_progress) {
+      RCLCPP_WARN_STREAM(logger_, "Trigger failure recovery in progress. Ignoring state change request.");
+      response->success = false;
+      return;
+    }
+  }
   response->success = true;
   if(request->transition.id == lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE) {
     RCLCPP_INFO_STREAM(logger_, "Recieved request to turn ON camera streams");

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1256,26 +1256,34 @@ void OBCameraNode::sendSoftwareTriggerCallback(
         response->rgb_camera_info = color_image_camera_info_;
         response->depth_camera_info = depth_image_camera_info_;
         // reset failure count on success
-        consecutive_trigger_failures_ = 0;
+        if (trigger_failure_monitor_) {
+          trigger_failure_monitor_->recordSuccess();
+        }
       } else {
         response->success = false;
         response->message = "Failed to capture images";
-        consecutive_trigger_failures_ += 1;
-        RCLCPP_WARN_STREAM(logger_, "Failed to capture images. Consecutive failures: "
-                                       << consecutive_trigger_failures_);
+        if (trigger_failure_monitor_) {
+          trigger_failure_monitor_->recordFailure();
+        }
       }
     } catch (const ob::Error& e) {
       response->message = e.getMessage();
       response->success = false;
-      consecutive_trigger_failures_ += 1;
+      if (trigger_failure_monitor_) {
+        trigger_failure_monitor_->recordFailure();
+      }
     } catch (const std::exception& e) {
       response->message = e.what();
       response->success = false;
-      consecutive_trigger_failures_ += 1;
+      if (trigger_failure_monitor_) {
+        trigger_failure_monitor_->recordFailure();
+      }
     } catch (...) {
       response->message = "unknown error";
       response->success = false;
-      consecutive_trigger_failures_ += 1;
+      if (trigger_failure_monitor_) {
+        trigger_failure_monitor_->recordFailure();
+      }
     }
     resetCaptureServiceVariables();
   } else {

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1206,7 +1206,7 @@ void OBCameraNode::handleChangeStateRequest(
       return;
     }
     // Activate streams
-    auto success = activate_streams();
+    auto success = activateStreams();
     response->success = success;
   }
   else if(request->transition.id == lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE) {
@@ -1217,7 +1217,7 @@ void OBCameraNode::handleChangeStateRequest(
       return;
     }
     // Deactivate streams
-    auto success = deactivate_streams();
+    auto success = deactivateStreams();
     response->success = success;
   }
   else {

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1205,23 +1205,9 @@ void OBCameraNode::handleChangeStateRequest(
       response->success = true;
       return;
     }
-    try {
-      setupProfiles();
-      startStreams();
-      RCLCPP_INFO_STREAM(logger_, "Camera streams are now ON");
-    } catch (const ob::Error& e) {
-      response->success = false;
-      RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: " << e.getMessage());
-      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
-    } catch (const std::exception& e) {
-      response->success = false;
-      RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: " << e.what());
-      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
-    } catch (...) {
-      response->success = false;
-      RCLCPP_ERROR_STREAM(logger_, "Failed to start camera streams: Unknown Error");
-      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
-    }
+    // Activate streams
+    auto success = activate_streams();
+    response->success = success;
   }
   else if(request->transition.id == lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE) {
     RCLCPP_INFO_STREAM(logger_, "Recieved request to turn OFF camera streams");
@@ -1230,22 +1216,9 @@ void OBCameraNode::handleChangeStateRequest(
       response->success = true;
       return;
     }
-    try {
-      stopStreams();
-      RCLCPP_INFO_STREAM(logger_, "Camera streams are now OFF");
-    } catch (const ob::Error& e) {
-      response->success = false;
-      RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.getMessage());
-      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
-    } catch (const std::exception& e) {
-      response->success = false;
-      RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: " << e.what());
-      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
-    } catch (...) {
-      response->success = false;
-      RCLCPP_ERROR_STREAM(logger_, "Failed to stop camera streams: Unknown Error");
-      set_state(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN);
-    }
+    // Deactivate streams
+    auto success = deactivate_streams();
+    response->success = success;
   }
   else {
     response->success = false;
@@ -1282,19 +1255,27 @@ void OBCameraNode::sendSoftwareTriggerCallback(
         response->depth_image = *(depth_image_);
         response->rgb_camera_info = color_image_camera_info_;
         response->depth_camera_info = depth_image_camera_info_;
+        // reset failure count on success
+        consecutive_trigger_failures_ = 0;
       } else {
         response->success = false;
         response->message = "Failed to capture images";
+        consecutive_trigger_failures_ += 1;
+        RCLCPP_WARN_STREAM(logger_, "Failed to capture images. Consecutive failures: "
+                                       << consecutive_trigger_failures_);
       }
     } catch (const ob::Error& e) {
       response->message = e.getMessage();
       response->success = false;
+      consecutive_trigger_failures_ += 1;
     } catch (const std::exception& e) {
       response->message = e.what();
       response->success = false;
+      consecutive_trigger_failures_ += 1;
     } catch (...) {
       response->message = "unknown error";
       response->success = false;
+      consecutive_trigger_failures_ += 1;
     }
     resetCaptureServiceVariables();
   } else {

--- a/orbbec_camera/src/trigger_failure_monitor.cpp
+++ b/orbbec_camera/src/trigger_failure_monitor.cpp
@@ -7,7 +7,9 @@ TriggerFailureMonitor::TriggerFailureMonitor(rclcpp::Node* node,
                                              const rclcpp::Logger& logger,
                                              int failures_before_recovery,
                                              double timer_period_seconds)
-    : node_(node), logger_(logger), failures_before_recovery_(failures_before_recovery),
+    : node_(node), 
+      logger_(logger), 
+      failures_before_recovery_(failures_before_recovery),
       timer_period_seconds_(timer_period_seconds) {
 
   RCLCPP_INFO_STREAM(logger_, "Setting up trigger failure monitor with period "

--- a/orbbec_camera/src/trigger_failure_monitor.cpp
+++ b/orbbec_camera/src/trigger_failure_monitor.cpp
@@ -73,14 +73,17 @@ void TriggerFailureMonitor::timerCallback() {
 }
 
 bool TriggerFailureMonitor::cycleStreams() {
+  recovery_in_progress_ = true;
   // Deactivate streams
   if (!deactivate_callback_) {
     RCLCPP_ERROR(logger_, "Deactivate callback not set, cannot perform recovery");
+    recovery_in_progress_ = false;
     return false;
   }
 
   if (!deactivate_callback_()) {
     RCLCPP_ERROR(logger_, "Failed to deactivate streams during trigger failure recovery");
+    recovery_in_progress_ = false;
     return false;
   }
 
@@ -89,15 +92,22 @@ bool TriggerFailureMonitor::cycleStreams() {
   // Reactivate streams
   if (!activate_callback_) {
     RCLCPP_ERROR(logger_, "Activate callback not set, cannot complete recovery");
+    recovery_in_progress_ = false;
     return false;
   }
 
   if (!activate_callback_()) {
     RCLCPP_ERROR(logger_, "Failed to reactivate streams during trigger failure recovery");
+    recovery_in_progress_ = false;
     return false;
   }
 
+  recovery_in_progress_ = false;
   return true;
+}
+
+bool TriggerFailureMonitor::isRecoveryInProgress() const {
+  return recovery_in_progress_;
 }
 
 }  // namespace orbbec_camera

--- a/orbbec_camera/src/trigger_failure_monitor.cpp
+++ b/orbbec_camera/src/trigger_failure_monitor.cpp
@@ -4,11 +4,11 @@
 namespace orbbec_camera {
 
 TriggerFailureMonitor::TriggerFailureMonitor(rclcpp::Node* node,
-                                             const rclcpp::Logger& logger)
-    : node_(node), logger_(logger) {
-  
-  setAndGetNodeParameter<int>(failures_before_recovery_, "trigger_failures_before_recovery", 2);
-  setAndGetNodeParameter<double>(timer_period_seconds_, "trigger_failure_monitor_timer_period", 1.0);
+                                             const rclcpp::Logger& logger,
+                                             int failures_before_recovery,
+                                             double timer_period_seconds)
+    : node_(node), logger_(logger), failures_before_recovery_(failures_before_recovery),
+      timer_period_seconds_(timer_period_seconds) {
 
   RCLCPP_INFO_STREAM(logger_, "Setting up trigger failure monitor with period "
                                   << timer_period_seconds_ << " seconds, "

--- a/orbbec_camera/src/trigger_failure_monitor.cpp
+++ b/orbbec_camera/src/trigger_failure_monitor.cpp
@@ -1,0 +1,101 @@
+#include "orbbec_camera/trigger_failure_monitor.h"
+#include <thread>
+
+namespace orbbec_camera {
+
+TriggerFailureMonitor::TriggerFailureMonitor(rclcpp::Node* node,
+                                             const rclcpp::Logger& logger)
+    : node_(node), logger_(logger) {
+  
+  setAndGetNodeParameter<int>(failures_before_recovery_, "trigger_failures_before_recovery", 2);
+  setAndGetNodeParameter<double>(timer_period_seconds_, "trigger_failure_monitor_timer_period", 1.0);
+
+  RCLCPP_INFO_STREAM(logger_, "Setting up trigger failure monitor with period "
+                                  << timer_period_seconds_ << " seconds, "
+                                  << "failures_before_recovery: "
+                                  << failures_before_recovery_);
+  
+  timer_ = node_->create_wall_timer(
+      std::chrono::duration<double>(timer_period_seconds_),
+      std::bind(&TriggerFailureMonitor::timerCallback, this));
+}
+
+TriggerFailureMonitor::~TriggerFailureMonitor() {
+  cleanup();
+}
+
+void TriggerFailureMonitor::setDeactivateCallback(StreamControlCallback callback) {
+  deactivate_callback_ = callback;
+}
+
+void TriggerFailureMonitor::setActivateCallback(StreamControlCallback callback) {
+  activate_callback_ = callback;
+}
+
+void TriggerFailureMonitor::setPipelineStatusCallback(PipelineStatusCallback callback) {
+  pipeline_status_callback_ = callback;
+}
+
+void TriggerFailureMonitor::recordFailure() {
+  consecutive_failures_++;
+}
+
+void TriggerFailureMonitor::recordSuccess() {
+  consecutive_failures_ = 0;
+}
+
+void TriggerFailureMonitor::cleanup() {
+  if (timer_) {
+    timer_->cancel();
+    timer_.reset();
+  }
+}
+
+void TriggerFailureMonitor::timerCallback() {
+  // Check if pipeline is running
+  if (pipeline_status_callback_ && !pipeline_status_callback_()) {
+    return;
+  }
+
+  if (consecutive_failures_ >= failures_before_recovery_) {
+    RCLCPP_WARN_STREAM(logger_, "Maximum consecutive trigger failures reached ("
+                                    << consecutive_failures_ << "), attempting recovery...");
+    
+    if (cycleStreams()) {
+      RCLCPP_INFO(logger_, "Stream recovery completed successfully");
+      consecutive_failures_ = 0;
+    } else {
+      RCLCPP_ERROR(logger_, "Stream recovery failed");
+    }
+  }
+}
+
+bool TriggerFailureMonitor::cycleStreams() {
+  // Deactivate streams
+  if (!deactivate_callback_) {
+    RCLCPP_ERROR(logger_, "Deactivate callback not set, cannot perform recovery");
+    return false;
+  }
+
+  if (!deactivate_callback_()) {
+    RCLCPP_ERROR(logger_, "Failed to deactivate streams during trigger failure recovery");
+    return false;
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+  // Reactivate streams
+  if (!activate_callback_) {
+    RCLCPP_ERROR(logger_, "Activate callback not set, cannot complete recovery");
+    return false;
+  }
+
+  if (!activate_callback_()) {
+    RCLCPP_ERROR(logger_, "Failed to reactivate streams during trigger failure recovery");
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace orbbec_camera


### PR DESCRIPTION
This adds a timer to monitor how many trigger failures we've seen in a row. If we surpass the limit, we deactivate and then reactivate the streams