### PR TITLE
[APG-1777] change camera origin

### DIFF
--- a/orbbec_description/urdf/gemini335Le_macro.urdf.xacro
+++ b/orbbec_description/urdf/gemini335Le_macro.urdf.xacro
@@ -163,7 +163,7 @@
     name="${name}_color_joint"
     type="fixed">
     <origin
-      xyz="0.034014 0.02375 0.014048"
+      xyz="${0.034014 - 0.00408} 0.02375 0.014048"
       rpy="0 0 0" />
     <parent
       link="${name}_link" />

--- a/orbbec_description/urdf/gemini335Le_macro.urdf.xacro
+++ b/orbbec_description/urdf/gemini335Le_macro.urdf.xacro
@@ -163,7 +163,7 @@
     name="${name}_color_joint"
     type="fixed">
     <origin
-      xyz="${0.034014 - 0.00408} 0.02375 0.014048"
+      xyz="0.029934 0.02375 0.014048"
       rpy="0 0 0" />
     <parent
       link="${name}_link" />


### PR DESCRIPTION
Camera origin currently on outside of glass, this moves it in based on the dimensions from orbbec datasheet.

Made [this](https://locusrobotics.atlassian.net/jira/software/projects/APG/boards/153?jql=assignee%20%3D%20712020%3A11468fc1-984e-4740-a109-f6f26005009e&selectedIssue=APG-2140) ticket to go through the urdf more thoroughly and add docs on where the values came from. This PR is just to get gazebo working asap