### PR TITLE
APG-2306 Adds warmup triggers to the trigger failure recovery, adds a get life cycle state service, and small bug fixes

### DIFF
--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -38,6 +38,7 @@
 #include <std_srvs/srv/empty.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <lifecycle_msgs/srv/change_state.hpp>
+#include <lifecycle_msgs/srv/get_state.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 
 #include <sensor_msgs/msg/camera_info.hpp>
@@ -598,6 +599,7 @@ class OBCameraNode {
   rclcpp::Service<SetFilter>::SharedPtr set_filter_srv_;
   rclcpp::Service<CameraTrigger>::SharedPtr capture_camera_images_srv_;
   rclcpp::Service<lifecycle_msgs::srv::ChangeState>::SharedPtr change_state_srv_;
+  rclcpp::Service<lifecycle_msgs::srv::GetState>::SharedPtr get_state_srv_;
   rclcpp::Service<orbbec_camera_msgs::srv::GetBool>::SharedPtr get_streams_enable_srv_;
   rclcpp::Service<SetInt32>::SharedPtr set_point_cloud_decimation_srv_;
   rclcpp::Service<GetInt32>::SharedPtr get_point_cloud_decimation_srv_;
@@ -884,6 +886,7 @@ class OBCameraNode {
 
   std::string intra_camera_sync_reference_ = "";
   rclcpp::Publisher<lifecycle_msgs::msg::State>::SharedPtr lifecycle_state_pub_;
+  uint8_t lifecycle_state_{lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN};
 
   // Trigger failure monitor for automatic recovery
   std::unique_ptr<TriggerFailureMonitor> trigger_failure_monitor_;

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -415,6 +415,9 @@ class OBCameraNode {
   void handleChangeStateRequest(
       const std::shared_ptr<lifecycle_msgs::srv::ChangeState::Request> request,
       std::shared_ptr<lifecycle_msgs::srv::ChangeState::Response> response);
+  
+  void handleGetStateRequest(const std::shared_ptr<lifecycle_msgs::srv::GetState::Request> request,
+                             std::shared_ptr<lifecycle_msgs::srv::GetState::Response> response);
 
   bool activateStreams();
 

--- a/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
+++ b/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
@@ -118,7 +118,8 @@ class TriggerFailureMonitor {
   
   StreamControlCallback deactivate_callback_;       
   StreamControlCallback activate_callback_;         
-  PipelineStatusCallback pipeline_status_callback_; 
+  PipelineStatusCallback pipeline_status_callback_;
+  TriggerCallback trigger_callback_;
   int failures_before_recovery_{2};
   double timer_period_seconds_{1.0}; 
   bool recovery_in_progress_{false};

--- a/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
+++ b/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
@@ -24,18 +24,25 @@ class TriggerFailureMonitor {
   using PipelineStatusCallback = std::function<bool()>;
 
   /**
+   * @brief Callback type for calling the trigger function
+   */
+  using TriggerCallback = std::function<void()>;
+
+  /**
    * @brief Constructor
    * @param node ROS node for creating timer
    * @param logger Logger for diagnostic messages
    * @param failures_before_recovery Number of failures before recovery
    * @param timer_period_seconds Timer period in seconds
    * @param period_between_restart_seconds Time to wait between deactivating and reactivating streams during recovery
+   * @param warmup_triggers_after_recovery Number of successful triggers to wait for after recovery before resuming normal monitoring
    */
   TriggerFailureMonitor(rclcpp::Node* node,
                         const rclcpp::Logger& logger,
                         int failures_before_recovery,
                         double timer_period_seconds,
-                        double period_between_restart_seconds);
+                        double period_between_restart_seconds,
+                        int warmup_triggers_after_recovery);
 
   /**
    * @brief Destructor - cleans up timer
@@ -59,6 +66,12 @@ class TriggerFailureMonitor {
    * @param callback Function to call to check if pipeline is running
    */
   void setPipelineStatusCallback(PipelineStatusCallback callback);
+
+  /**
+   * @brief Set callback to call the trigger function
+   * @param callback Function to call to perform a trigger
+   */
+  void setTriggerCallback(TriggerCallback callback);
 
   /**
    * @brief Record a trigger failure
@@ -110,6 +123,7 @@ class TriggerFailureMonitor {
   double timer_period_seconds_{1.0}; 
   bool recovery_in_progress_{false};
   double period_between_restart_seconds_{0.25};
+  int warmup_triggers_after_recovery_{5};
 };
 
 }  // namespace orbbec_camera

--- a/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
+++ b/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
@@ -29,11 +29,13 @@ class TriggerFailureMonitor {
    * @param logger Logger for diagnostic messages
    * @param failures_before_recovery Number of failures before recovery
    * @param timer_period_seconds Timer period in seconds
+   * @param period_between_restart_seconds Time to wait between deactivating and reactivating streams during recovery
    */
   TriggerFailureMonitor(rclcpp::Node* node,
                         const rclcpp::Logger& logger,
                         int failures_before_recovery,
-                        double timer_period_seconds);
+                        double timer_period_seconds,
+                        double period_between_restart_seconds);
 
   /**
    * @brief Destructor - cleans up timer
@@ -107,6 +109,7 @@ class TriggerFailureMonitor {
   int failures_before_recovery_{2};
   double timer_period_seconds_{1.0}; 
   bool recovery_in_progress_{false};
+  double period_between_restart_seconds_{0.25};
 };
 
 }  // namespace orbbec_camera

--- a/orbbec_camera/launch/gemini_330_series.launch.py
+++ b/orbbec_camera/launch/gemini_330_series.launch.py
@@ -366,7 +366,7 @@ def generate_launch_description():
                     executable="component_container",
                     respawn=respawn,
                     respawn_delay=respawn_delay,
-                    composable_node_descriptions=[camera_component],
+                    composable_node_descriptions=[],
                     output=output,
                     arguments=['--ros-args', '--log-level', 'INFO'],
                 )
@@ -382,6 +382,7 @@ def generate_launch_description():
                         TimerAction(
                             period=1.0,
                             actions=[
+                                PushRosNamespace(namespace),
                                 LoadComposableNodes(
                                     composable_node_descriptions=[camera_component],
                                     target_container=container,

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2215,15 +2215,17 @@ void OBCameraNode::setupTriggerFailureMonitor() {
   bool enabled;
   int failures_before_recovery;
   double timer_period_seconds;
+  double period_between_restart_seconds;
   setAndGetNodeParameter<bool>(enabled, "enable_trigger_failure_monitor", service_trigger_enabled_);
   setAndGetNodeParameter<int>(failures_before_recovery, "trigger_failures_before_recovery", 2);
   setAndGetNodeParameter<double>(timer_period_seconds, "trigger_failure_monitor_timer_period", 1.0);
+  setAndGetNodeParameter<double>(period_between_restart_seconds, "trigger_failure_period_between_restart", 0.25);
   if (!enabled) {
     RCLCPP_INFO_STREAM(logger_, "Trigger failure monitor is disabled");
     return;
   }
   trigger_failure_monitor_ = std::make_unique<TriggerFailureMonitor>(
-      node_, logger_, failures_before_recovery, timer_period_seconds);
+      node_, logger_, failures_before_recovery, timer_period_seconds, period_between_restart_seconds);
   // Set up callbacks for stream control and pipeline status
   trigger_failure_monitor_->setActivateCallback(
       std::bind(&OBCameraNode::activateStreams, this));
@@ -2508,6 +2510,7 @@ void OBCameraNode::setupPublishers() {
 void OBCameraNode::set_state(uint8_t state) {
   lifecycle_msgs::msg::State msg;
   msg.id = state;
+  lifecycle_state_ = state;
   lifecycle_state_pub_->publish(msg);
 }
 

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2216,16 +2216,19 @@ void OBCameraNode::setupTriggerFailureMonitor() {
   int failures_before_recovery;
   double timer_period_seconds;
   double period_between_restart_seconds;
+  int warmup_triggers_after_recovery;
   setAndGetNodeParameter<bool>(enabled, "enable_trigger_failure_monitor", service_trigger_enabled_);
   setAndGetNodeParameter<int>(failures_before_recovery, "trigger_failures_before_recovery", 2);
   setAndGetNodeParameter<double>(timer_period_seconds, "trigger_failure_monitor_timer_period", 1.0);
   setAndGetNodeParameter<double>(period_between_restart_seconds, "trigger_failure_period_between_restart", 0.25);
+  setAndGetNodeParameter<int>(warmup_triggers_after_recovery, "trigger_failure_warmup_triggers_after_recovery", 5);
   if (!enabled) {
     RCLCPP_INFO_STREAM(logger_, "Trigger failure monitor is disabled");
     return;
   }
   trigger_failure_monitor_ = std::make_unique<TriggerFailureMonitor>(
-      node_, logger_, failures_before_recovery, timer_period_seconds, period_between_restart_seconds);
+      node_, logger_, failures_before_recovery, timer_period_seconds,
+      period_between_restart_seconds, warmup_triggers_after_recovery);
   // Set up callbacks for stream control and pipeline status
   trigger_failure_monitor_->setActivateCallback(
       std::bind(&OBCameraNode::activateStreams, this));
@@ -2233,6 +2236,10 @@ void OBCameraNode::setupTriggerFailureMonitor() {
       std::bind(&OBCameraNode::deactivateStreams, this));
   trigger_failure_monitor_->setPipelineStatusCallback(
       [this]() { return pipeline_started_.load(); });
+  trigger_failure_monitor->setTriggerCallback(
+      [this]() {
+        TRY_EXECUTE_BLOCK(device_->triggerCapture());
+      });
 }
 
 void OBCameraNode::setupDiagnosticUpdater() {

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2236,7 +2236,7 @@ void OBCameraNode::setupTriggerFailureMonitor() {
       std::bind(&OBCameraNode::deactivateStreams, this));
   trigger_failure_monitor_->setPipelineStatusCallback(
       [this]() { return pipeline_started_.load(); });
-  trigger_failure_monitor->setTriggerCallback(
+  trigger_failure_monitor_->setTriggerCallback(
       [this]() {
         TRY_EXECUTE_BLOCK(device_->triggerCapture());
       });

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1280,9 +1280,8 @@ void OBCameraNode::resetCaptureServiceVariables() {
 }
 
 void OBCameraNode::handleGetStateRequest(
-    const std::shared_ptr<lifecycle_msgs::srv::GetState::Request> request,
+    const std::shared_ptr<lifecycle_msgs::srv::GetState::Request> /* request */,
         std::shared_ptr<lifecycle_msgs::srv::GetState::Response> response) {
-  (void)request;
   lifecycle_msgs::msg::State state;
   state.id = lifecycle_state_;
   response->current_state = state;

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -1284,8 +1284,7 @@ void OBCameraNode::handleGetStateRequest(
         std::shared_ptr<lifecycle_msgs::srv::GetState::Response> response) {
   (void)request;
   lifecycle_msgs::msg::State state;
-  state.id = current_state_.id;
-  state.label = current_state_.label;
+  state.id = lifecycle_state_;
   response->current_state = state;
 }
 

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -232,47 +232,50 @@ void OBCameraNode::setupCameraCtrlServices() {
         sendSoftwareTriggerCallback(request, response);
       });
   write_customerdata_srv_ = node_->create_service<SetString>(
-      "write_customer_data", [this](const std::shared_ptr<SetString::Request> request,
+      camera_name_ + "/""write_customer_data", [this](const std::shared_ptr<SetString::Request> request,
                                     std::shared_ptr<SetString::Response> response) {
         writeCustomerDataCallback(request, response);
       });
   read_customerdata_srv_ = node_->create_service<GetString>(
-      "read_customer_data", [this](const std::shared_ptr<GetString::Request> request,
+      camera_name_ + "/" + "read_customer_data", [this](const std::shared_ptr<GetString::Request> request,
                                    std::shared_ptr<GetString::Response> response) {
         readCustomerDataCallback(request, response);
       });
   set_user_calib_params_srv_ = node_->create_service<SetUserCalibParams>(
-      "set_user_calib_params", [this](const std::shared_ptr<SetUserCalibParams::Request> request,
+      camera_name_ + "/" + "set_user_calib_params", [this](const std::shared_ptr<SetUserCalibParams::Request> request,
                                       std::shared_ptr<SetUserCalibParams::Response> response) {
         setUserCalibParamsCallback(request, response);
       });
   get_user_calib_params_srv_ = node_->create_service<GetUserCalibParams>(
-      "get_user_calib_params", [this](const std::shared_ptr<GetUserCalibParams::Request> request,
+      camera_name_ + "/" + "get_user_calib_params", [this](const std::shared_ptr<GetUserCalibParams::Request> request,
                                       std::shared_ptr<GetUserCalibParams::Response> response) {
         getUserCalibParamsCallback(request, response);
       });
   set_streams_enable_srv_ = node_->create_service<SetBool>(
-      "set_streams_enable", [this](const std::shared_ptr<SetBool::Request> request,
+      camera_name_ + "/" + "set_streams_enable", [this](const std::shared_ptr<SetBool::Request> request,
                                    std::shared_ptr<SetBool::Response> response) {
         setStreamsEnableCallback(request, response);
       });
   get_streams_enable_srv_ = node_->create_service<GetBool>(
-      "get_streams_enable", [this](const std::shared_ptr<GetBool::Request> request,
+      camera_name_ + "/" + "get_streams_enable", [this](const std::shared_ptr<GetBool::Request> request,
                                    std::shared_ptr<GetBool::Response> response) {
         getStreamsEnableCallback(request, response);
       });
   set_point_cloud_decimation_srv_ = node_->create_service<SetInt32>(
-      "set_point_cloud_decimation", [this](const std::shared_ptr<SetInt32::Request> request,
+      camera_name_ + "/" + "set_point_cloud_decimation", [this](const std::shared_ptr<SetInt32::Request> request,
                                             std::shared_ptr<SetInt32::Response> response) {
         setPointCloudDecimationCallback(request, response);
       });
   get_point_cloud_decimation_srv_ = node_->create_service<GetInt32>(
-      "get_point_cloud_decimation", [this](const std::shared_ptr<GetInt32::Request> request,
+      camera_name_ + "/" + "get_point_cloud_decimation", [this](const std::shared_ptr<GetInt32::Request> request,
                                             std::shared_ptr<GetInt32::Response> response) {
         getPointCloudDecimationCallback(request, response);
       });
   change_state_srv_ = node_->create_service<lifecycle_msgs::srv::ChangeState>(
       camera_name_ + "/" + "change_state", std::bind(&OBCameraNode::handleChangeStateRequest, this,
+                              std::placeholders::_1, std::placeholders::_2));
+  get_state_srv_ = node_->create_service<lifecycle_msgs::srv::GetState>(
+      camera_name_ + "/" + "get_state", std::bind(&OBCameraNode::handleGetStateRequest, this,
                               std::placeholders::_1, std::placeholders::_2));
 
 }
@@ -1274,6 +1277,16 @@ void OBCameraNode::resetCaptureServiceVariables() {
   service_capture_started_ = false;
   number_of_rgb_frames_captured_ = 0;
   number_of_depth_frames_captured_ = 0;
+}
+
+void OBCameraNode::handleGetStateRequest(
+    const std::shared_ptr<lifecycle_msgs::srv::GetState::Request> request,
+        std::shared_ptr<lifecycle_msgs::srv::GetState::Response> response) {
+  (void)request;
+  lifecycle_msgs::msg::State state;
+  state.id = current_state_.id;
+  state.label = current_state_.label;
+  response->current_state = state;
 }
 
 void OBCameraNode::handleChangeStateRequest(

--- a/orbbec_camera/src/trigger_failure_monitor.cpp
+++ b/orbbec_camera/src/trigger_failure_monitor.cpp
@@ -7,12 +7,14 @@ TriggerFailureMonitor::TriggerFailureMonitor(rclcpp::Node* node,
                                              const rclcpp::Logger& logger,
                                              int failures_before_recovery,
                                              double timer_period_seconds,
-                                            double period_between_restart_seconds)
+                                             double period_between_restart_seconds,
+                                             int warmup_triggers_after_recovery)
     : node_(node), 
       logger_(logger), 
       failures_before_recovery_(failures_before_recovery),
       timer_period_seconds_(timer_period_seconds),
-      period_between_restart_seconds_(period_between_restart_seconds) {
+      period_between_restart_seconds_(period_between_restart_seconds),
+      warmup_triggers_after_recovery_(warmup_triggers_after_recovery) {
 
   RCLCPP_INFO_STREAM(logger_, "Setting up trigger failure monitor with period "
                                   << timer_period_seconds_ << " seconds, "
@@ -40,6 +42,10 @@ void TriggerFailureMonitor::setActivateCallback(StreamControlCallback callback) 
 
 void TriggerFailureMonitor::setPipelineStatusCallback(PipelineStatusCallback callback) {
   pipeline_status_callback_ = callback;
+}
+
+void TriggerFailureMonitor::setTriggerCallback(TriggerCallback callback) {
+  trigger_callback_ = callback;
 }
 
 void TriggerFailureMonitor::recordFailure() {
@@ -104,6 +110,11 @@ bool TriggerFailureMonitor::cycleStreams() {
     RCLCPP_ERROR(logger_, "Failed to reactivate streams during trigger failure recovery");
     recovery_in_progress_ = false;
     return false;
+  }
+  for (int i = 0; i < warmup_triggers_after_recovery_; ++i) {
+    if (trigger_callback_) {
+      trigger_callback_();
+    }
   }
 
   recovery_in_progress_ = false;

--- a/orbbec_camera/src/trigger_failure_monitor.cpp
+++ b/orbbec_camera/src/trigger_failure_monitor.cpp
@@ -6,17 +6,21 @@ namespace orbbec_camera {
 TriggerFailureMonitor::TriggerFailureMonitor(rclcpp::Node* node,
                                              const rclcpp::Logger& logger,
                                              int failures_before_recovery,
-                                             double timer_period_seconds)
+                                             double timer_period_seconds,
+                                            double period_between_restart_seconds)
     : node_(node), 
       logger_(logger), 
       failures_before_recovery_(failures_before_recovery),
-      timer_period_seconds_(timer_period_seconds) {
+      timer_period_seconds_(timer_period_seconds),
+      period_between_restart_seconds_(period_between_restart_seconds) {
 
   RCLCPP_INFO_STREAM(logger_, "Setting up trigger failure monitor with period "
                                   << timer_period_seconds_ << " seconds, "
                                   << "failures_before_recovery: "
-                                  << failures_before_recovery_);
-  
+                                  << failures_before_recovery_ 
+                                  << ", period_between_restart_seconds: "
+                                  << period_between_restart_seconds_);
+
   timer_ = node_->create_wall_timer(
       std::chrono::duration<double>(timer_period_seconds_),
       std::bind(&TriggerFailureMonitor::timerCallback, this));
@@ -87,7 +91,7 @@ bool TriggerFailureMonitor::cycleStreams() {
     return false;
   }
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  std::this_thread::sleep_for(std::chrono::duration<double>(period_between_restart_seconds_));
 
   // Reactivate streams
   if (!activate_callback_) {


### PR DESCRIPTION
This PR adds warmup triggers to the trigger failure monitor's recovery and parametrizes the time waiting in between deactivating/reactivating the streams.

We also add a service to get the life cycle state so that other nodes can determine if we are ready to take in more trigger requests.

Also some adjustments were made to the launch file to fix a bug where two instances of the driver get launched. The respawn functionality was re-tested by sending a kill signal to the container and verifying that the container comes back up. The trigger service was also tested after the node respawns