### PR TITLE
Add variable for SDK log path

### DIFF
--- a/orbbec_camera/launch/gemini_330_series.launch.py
+++ b/orbbec_camera/launch/gemini_330_series.launch.py
@@ -199,6 +199,7 @@ def generate_launch_description():
         DeclareLaunchArgument('exposure_range_mode', default_value='default'),#default, ultimate or regular
         DeclareLaunchArgument('log_level', default_value='none'),
         DeclareLaunchArgument('log_file_name', default_value=''),
+        DeclareLaunchArgument('log_file_path', default_value=''),
         DeclareLaunchArgument('enable_publish_extrinsic', default_value='false'),
         DeclareLaunchArgument('enable_d2c_viewer', default_value='false'),
         DeclareLaunchArgument('disparity_to_depth_mode', default_value='HW'),

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -198,7 +198,7 @@ void OBCameraNodeDriver::init() {
   auto log_level = obLogSeverityFromString(log_level_str);
   auto log_file_name = declare_parameter<std::string>("log_file_name", "");
   auto log_file_path = declare_parameter<std::string>("log_file_path", "");
-  if (!log_file_path) {
+  if (log_file_name.empty()) {
     std::string pwd_dir = std::getenv("PWD") ? std::getenv("PWD") : std::getenv("HOME");
     log_file_path = pwd_dir + "/Log/" + g_camera_name;
   }

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -197,11 +197,14 @@ void OBCameraNodeDriver::init() {
   auto log_level_str = declare_parameter<std::string>("log_level", "none");
   auto log_level = obLogSeverityFromString(log_level_str);
   auto log_file_name = declare_parameter<std::string>("log_file_name", "");
-  std::string pwd_dir = std::getenv("PWD") ? std::getenv("PWD") : std::getenv("HOME");
-  std::string log_path = pwd_dir + "/Log/" + g_camera_name;
+  auto log_file_path = declare_parameter<std::string>("log_file_path", "");
+  if (!log_file_path) {
+    std::string pwd_dir = std::getenv("PWD") ? std::getenv("PWD") : std::getenv("HOME");
+    log_file_path = pwd_dir + "/Log/" + g_camera_name;
+  }
   // Set logger to console
   ob::Context::setLoggerToConsole(log_level);
-  ob::Context::setLoggerToFile(log_level, log_path.c_str());
+  ob::Context::setLoggerToFile(log_level, log_file_path.c_str());
   // Set custom log file name if specified
   if (!log_file_name.empty()) {
     try {


### PR DESCRIPTION
This PR adds a variable to set the path for the SDK logs will be written to. This will allow us to stick the logs in to the .ros folder