### PR TITLE
APG-2731: Publish camera name on device disconnect

### DIFF
--- a/orbbec_camera/include/orbbec_camera/ob_camera_node_driver.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node_driver.h
@@ -25,6 +25,7 @@
 #include "utils.h"
 #include "dynamic_params.h"
 #include <orbbec_camera_msgs/msg/device_status.hpp>
+#include <std_msgs/msg/string.hpp>
 
 #include "libobsensor/ObSensor.hpp"
 #include <pthread.h>
@@ -143,6 +144,8 @@ class OBCameraNodeDriver : public rclcpp::Node {
   rclcpp::TimerBase::SharedPtr device_status_timer_ = nullptr;
   int device_status_interval_hz = 2;  // 2Hz
   rclcpp::Publisher<orbbec_camera_msgs::msg::DeviceStatus>::SharedPtr device_status_pub_ = nullptr;
+  // Publishes the camera name whenever this driver's device disconnects, for metrics bridging.
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr disconnect_event_pub_ = nullptr;
   std::string node_name_;
   bool force_ip_enable_{false};
   bool force_ip_dhcp_{false};

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -318,6 +318,11 @@ void OBCameraNodeDriver::init() {
   // Initialize device status publisher
   device_status_pub_ = this->create_publisher<orbbec_camera_msgs::msg::DeviceStatus>(
       "device_status", rclcpp::QoS(1).transient_local());
+
+  // Publishes the camera name when this driver's device disconnects, consumed by the
+  // ros_victoria_metrics_bridge as a counter source (no array_metrics_msgs dependency).
+  disconnect_event_pub_ =
+      this->create_publisher<std_msgs::msg::String>("/orbbec_disconnect_events", rclcpp::QoS(10));
 }
 
 void OBCameraNodeDriver::onDeviceConnected(const std::shared_ptr<ob::DeviceList> &device_list) {
@@ -382,6 +387,12 @@ void OBCameraNodeDriver::onDeviceDisconnected(const std::shared_ptr<ob::DeviceLi
     if (uid == device_unique_id_ || serial_number_ == serial_number) {
       RCLCPP_INFO_STREAM(logger_,
                          "device with " << uid << " disconnected, notify reset device thread 1.");
+      // Emit a disconnect event with the camera name for the metrics bridge.
+      if (disconnect_event_pub_) {
+        std_msgs::msg::String disconnect_msg;
+        disconnect_msg.data = g_camera_name;
+        disconnect_event_pub_->publish(disconnect_msg);
+      }
       reset_device_flag_ = true;
       reset_device_cond_.notify_all();
       RCLCPP_INFO_STREAM(logger_,

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -319,8 +319,7 @@ void OBCameraNodeDriver::init() {
   device_status_pub_ = this->create_publisher<orbbec_camera_msgs::msg::DeviceStatus>(
       "device_status", rclcpp::QoS(1).transient_local());
 
-  // Publishes the camera name when this driver's device disconnects, consumed by the
-  // ros_victoria_metrics_bridge as a counter source (no array_metrics_msgs dependency).
+  // Publishes the camera name when this driver's device disconnects.
   disconnect_event_pub_ =
       this->create_publisher<std_msgs::msg::String>("/orbbec_disconnect_events", rclcpp::QoS(10));
 }


### PR DESCRIPTION
Sets things up to use the new ros2 grafana bridge so people can track disconnect errors.