### PR TITLE
[APG-2626] orbbec_camera: port to ROS L (lyrical)

### DIFF
--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -59,7 +59,6 @@ set(dependencies_targets
     cv_bridge::cv_bridge
     camera_info_manager::camera_info_manager
     image_transport::image_transport
-    image_publisher::image_publisher
     ${lifecycle_msgs_TARGETS}
     ${orbbec_camera_msgs_TARGETS}
     rclcpp::rclcpp

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -50,6 +50,33 @@ foreach(dep IN LISTS dependencies)
     find_package(${dep} REQUIRED)
 endforeach()
 
+# ament_target_dependencies() was removed in ROS L (lyrical); link modern CMake
+# targets directly. Eigen3, OpenCV, Threads and yaml-cpp are linked via
+# COMMON_LIBRARIES; backward_ros injects itself on find_package.
+set(dependencies_targets
+    ament_index_cpp::ament_index_cpp
+    ${builtin_interfaces_TARGETS}
+    cv_bridge::cv_bridge
+    camera_info_manager::camera_info_manager
+    image_transport::image_transport
+    image_publisher::image_publisher
+    ${lifecycle_msgs_TARGETS}
+    ${orbbec_camera_msgs_TARGETS}
+    rclcpp::rclcpp
+    rclcpp_components::component
+    ${sensor_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    ${std_srvs_TARGETS}
+    tf2::tf2
+    ${tf2_msgs_TARGETS}
+    tf2_ros::tf2_ros
+    tf2_sensor_msgs::tf2_sensor_msgs
+    diagnostic_updater::diagnostic_updater
+    ${diagnostic_msgs_TARGETS}
+    ${statistics_msgs_TARGETS}
+    camera_calibration_parsers::camera_calibration_parsers
+)
+
 find_package(PkgConfig REQUIRED)
 
 if(USE_RK_HW_DECODER)
@@ -171,13 +198,13 @@ macro(add_orbbec_executable TARGET SOURCE)
     add_executable(${TARGET} ${SOURCE})
     target_include_directories(${TARGET} PUBLIC ${COMMON_INCLUDE_DIRS})
     target_link_libraries(${TARGET} ${COMMON_LIBRARIES} ${PROJECT_NAME})
-    ament_target_dependencies(${TARGET} ${dependencies})
+    target_link_libraries(${TARGET} ${dependencies_targets})
 endmacro()
 
 # Define library and nodes
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} ${dependencies_targets})
 target_include_directories(${PROJECT_NAME} PUBLIC ${COMMON_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} ${COMMON_LIBRARIES})
 
@@ -205,14 +232,14 @@ install(
 add_library(frame_latency SHARED tools/frame_latency.cpp)
 target_include_directories(frame_latency PUBLIC ${COMMON_INCLUDE_DIRS})
 target_link_libraries(frame_latency ${COMMON_LIBRARIES})
-ament_target_dependencies(frame_latency ${dependencies})
+target_link_libraries(frame_latency ${dependencies_targets})
 
 rclcpp_components_register_node(frame_latency PLUGIN "orbbec_camera::FrameLatencyNode" EXECUTABLE frame_latency_node)
 
 add_library(start_benchmark SHARED tools/start_benchmark.cpp)
 target_include_directories(start_benchmark PUBLIC ${COMMON_INCLUDE_DIRS})
 target_link_libraries(start_benchmark ${COMMON_LIBRARIES})
-ament_target_dependencies(start_benchmark ${dependencies})
+target_link_libraries(start_benchmark ${dependencies_targets})
 
 rclcpp_components_register_node(
     start_benchmark PLUGIN "orbbec_camera::tools::StartBenchmark" EXECUTABLE start_benchmark_node
@@ -221,7 +248,7 @@ rclcpp_components_register_node(
 add_library(multi_save_rgbir SHARED tools/multi_save_rgbir.cpp src/utils.cpp)
 target_include_directories(multi_save_rgbir PUBLIC ${COMMON_INCLUDE_DIRS})
 target_link_libraries(multi_save_rgbir ${COMMON_LIBRARIES})
-ament_target_dependencies(multi_save_rgbir ${dependencies})
+target_link_libraries(multi_save_rgbir ${dependencies_targets})
 
 rclcpp_components_register_node(
     multi_save_rgbir PLUGIN "orbbec_camera::tools::MultiCameraSubscriber" EXECUTABLE multi_save_rgbir_node

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -25,6 +25,7 @@ set(dependencies
     backward_ros
     camera_info_manager
     image_transport
+    message_filters
     image_publisher
     lifecycle_msgs
     OpenCV
@@ -59,6 +60,7 @@ set(dependencies_targets
     cv_bridge::cv_bridge
     camera_info_manager::camera_info_manager
     image_transport::image_transport
+    message_filters::message_filters
     ${lifecycle_msgs_TARGETS}
     ${orbbec_camera_msgs_TARGETS}
     rclcpp::rclcpp

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -12,7 +12,9 @@ option(USE_NV_HW_DECODER "Use Nvidia hardware decoder" OFF)
 option(INSTALL_UDEV_RULES "Install udev rule for Orbbec cameras" ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Werror -Wno-pedantic -Wno-array-bounds)
+    # ROS L (lyrical) deprecates the rmw_qos_profile_t QoS overloads (image_transport,
+    # rclcpp, ...) that this driver still uses; keep them as warnings, not errors.
+    add_compile_options(-Wall -Wextra -Werror -Wno-error=deprecated-declarations -Wno-pedantic -Wno-array-bounds)
 endif()
 
 # find dependencies

--- a/orbbec_camera/examples/multi_camera_time_sync/image_sync_example_node.cpp
+++ b/orbbec_camera/examples/multi_camera_time_sync/image_sync_example_node.cpp
@@ -1,4 +1,5 @@
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/version.h>
 #include <sensor_msgs/msg/image.hpp>
 #include <message_filters/subscriber.hpp>
 #include <message_filters/synchronizer.hpp>
@@ -7,7 +8,7 @@
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>
 #elif __has_include(<cv_bridge/cv_bridge.h>)
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.h>
 #endif
 #include <opencv2/opencv.hpp>
 #include <iostream>
@@ -56,14 +57,20 @@ class ImageSyncNode : public rclcpp::Node {
     rclcpp::QoS qos(rclcpp::KeepLast(10));
     qos.reliable();
 
-    camera_01_color_sub_.subscribe(this, "/camera_01/color/image_raw", qos.get_rmw_qos_profile());
-    camera_01_depth_sub_.subscribe(this, "/camera_01/depth/image_raw", qos.get_rmw_qos_profile());
-    camera_02_color_sub_.subscribe(this, "/camera_02/color/image_raw", qos.get_rmw_qos_profile());
-    camera_02_depth_sub_.subscribe(this, "/camera_02/depth/image_raw", qos.get_rmw_qos_profile());
-    camera_03_color_sub_.subscribe(this, "/camera_03/color/image_raw", qos.get_rmw_qos_profile());
-    camera_03_depth_sub_.subscribe(this, "/camera_03/depth/image_raw", qos.get_rmw_qos_profile());
-    camera_04_color_sub_.subscribe(this, "/camera_04/color/image_raw", qos.get_rmw_qos_profile());
-    camera_04_depth_sub_.subscribe(this, "/camera_04/depth/image_raw", qos.get_rmw_qos_profile());
+#if RCLCPP_VERSION_GTE(32, 0, 0)
+    const rclcpp::QoS & mf_qos = qos;
+#else
+    const rmw_qos_profile_t mf_qos = qos.get_rmw_qos_profile();
+#endif
+
+    camera_01_color_sub_.subscribe(this, "/camera_01/color/image_raw", mf_qos);
+    camera_01_depth_sub_.subscribe(this, "/camera_01/depth/image_raw", mf_qos);
+    camera_02_color_sub_.subscribe(this, "/camera_02/color/image_raw", mf_qos);
+    camera_02_depth_sub_.subscribe(this, "/camera_02/depth/image_raw", mf_qos);
+    camera_03_color_sub_.subscribe(this, "/camera_03/color/image_raw", mf_qos);
+    camera_03_depth_sub_.subscribe(this, "/camera_03/depth/image_raw", mf_qos);
+    camera_04_color_sub_.subscribe(this, "/camera_04/color/image_raw", mf_qos);
+    camera_04_depth_sub_.subscribe(this, "/camera_04/depth/image_raw", mf_qos);
 
     sync_ =
         std::make_shared<Sync>(SyncPolicy(10), camera_01_color_sub_, camera_01_depth_sub_,

--- a/orbbec_camera/examples/multi_camera_time_sync/image_sync_example_node.cpp
+++ b/orbbec_camera/examples/multi_camera_time_sync/image_sync_example_node.cpp
@@ -1,13 +1,13 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/synchronizer.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>
 #elif __has_include(<cv_bridge/cv_bridge.h>)
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 #include <opencv2/opencv.hpp>
 #include <iostream>

--- a/orbbec_camera/include/orbbec_camera/d2c_viewer.h
+++ b/orbbec_camera/include/orbbec_camera/d2c_viewer.h
@@ -14,10 +14,10 @@
 * limitations under the License.
 *******************************************************************************/
 #pragma once
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/time_synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/synchronizer.hpp>
+#include <message_filters/time_synchronizer.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <rclcpp/rclcpp.hpp>
 

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -44,7 +44,6 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <camera_info_manager/camera_info_manager.hpp>
 
-#include <image_publisher/image_publisher.hpp>
 #include <image_transport/publisher.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include "libobsensor/ObSensor.hpp"

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -29,11 +29,11 @@
 #include <opencv2/opencv.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <tf2_ros/static_transform_broadcaster.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Transform.h>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
@@ -80,7 +80,7 @@
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>
 #elif __has_include(<cv_bridge/cv_bridge.h>)
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 
 #define STREAM_NAME(sip)                                                                       \

--- a/orbbec_camera/include/orbbec_camera/ob_lidar_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_lidar_node.h
@@ -43,7 +43,6 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <camera_info_manager/camera_info_manager.hpp>
 
-#include <image_publisher/image_publisher.hpp>
 #include <image_transport/publisher.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include "libobsensor/ObSensor.hpp"

--- a/orbbec_camera/include/orbbec_camera/ob_lidar_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_lidar_node.h
@@ -31,11 +31,11 @@
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <tf2_ros/static_transform_broadcaster.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Transform.h>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
@@ -73,7 +73,7 @@
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>
 #elif __has_include(<cv_bridge/cv_bridge.h>)
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 
 #define STREAM_NAME(sip)                                                                       \

--- a/orbbec_camera/include/orbbec_camera/utils.h
+++ b/orbbec_camera/include/orbbec_camera/utils.h
@@ -17,7 +17,7 @@
 #pragma once
 #include <ostream>
 #include <Eigen/Dense>
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "libobsensor/ObSensor.hpp"

--- a/orbbec_camera/src/d2c_viewer.cpp
+++ b/orbbec_camera/src/d2c_viewer.cpp
@@ -17,9 +17,10 @@
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>
 #elif __has_include(<cv_bridge/cv_bridge.h>)
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.h>
 #endif
 #include <sensor_msgs/image_encodings.hpp>
+#include <rclcpp/version.h>
 
 #include <opencv2/opencv.hpp>
 
@@ -29,10 +30,17 @@ namespace orbbec_camera {
 D2CViewer::D2CViewer(rclcpp::Node* const node, rmw_qos_profile_t rgb_qos,
                      rmw_qos_profile_t depth_qos, bool use_intra_process)
     : node_(node), logger_(rclcpp::get_logger("d2c_viewer")), is_active_(true) {
+#if RCLCPP_VERSION_GTE(32, 0, 0)
+  rgb_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
+      node_, "color/image_raw", rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rgb_qos), rgb_qos));
+  depth_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
+      node_, "depth/image_raw", rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(depth_qos), depth_qos));
+#else
   rgb_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
       node_, "color/image_raw", rgb_qos);
   depth_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
       node_, "depth/image_raw", depth_qos);
+#endif
   sync_ = std::make_shared<message_filters::Synchronizer<MySyncPolicy>>(MySyncPolicy(10), *rgb_sub_,
                                                                         *depth_sub_);
   sync_->setMaxIntervalDuration(rclcpp::Duration::from_seconds(1.0));  // 1s

--- a/orbbec_camera/src/d2c_viewer.cpp
+++ b/orbbec_camera/src/d2c_viewer.cpp
@@ -17,7 +17,7 @@
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>
 #elif __has_include(<cv_bridge/cv_bridge.h>)
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 #include <sensor_msgs/image_encodings.hpp>
 

--- a/orbbec_camera/tools/multi_save_rgbir.cpp
+++ b/orbbec_camera/tools/multi_save_rgbir.cpp
@@ -5,9 +5,9 @@
 #include <orbbec_camera/utils.h>
 #include "orbbec_camera/ob_camera_node.h"
 #include "orbbec_camera_msgs/msg/metadata.hpp"
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/synchronizer.hpp>
 #include <std_msgs/msg/int32.hpp>
 #include <filesystem>
 #include <regex>

--- a/orbbec_camera/tools/ob_benchmark.cpp
+++ b/orbbec_camera/tools/ob_benchmark.cpp
@@ -3,9 +3,9 @@
 #include <orbbec_camera/ob_camera_node_driver.h>
 #include <orbbec_camera/utils.h>
 #include "orbbec_camera_msgs/msg/metadata.hpp"
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/synchronizer.hpp>
 #include <filesystem>
 
 namespace orbbec_camera {

--- a/orbbec_camera/tools/start_benchmark.cpp
+++ b/orbbec_camera/tools/start_benchmark.cpp
@@ -3,9 +3,9 @@
 #include <orbbec_camera/ob_camera_node_driver.h>
 #include <orbbec_camera/utils.h>
 #include "orbbec_camera_msgs/msg/metadata.hpp"
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/synchronizer.hpp>
 #include <filesystem>
 
 namespace orbbec_camera {


### PR DESCRIPTION
Ports orbbec_camera to build on ROS L (lyrical / Ubuntu 26.04), kept jazzy-compatible throughout. Validated with a colcon build on lyrical.

- Replace `ament_target_dependencies` (removed in lyrical) with modern `target_link_libraries` (`pkg::pkg` / `${pkg_TARGETS}`); drop `image_publisher` from link targets and declare `message_filters` explicitly.
- Migrate `.h`→`.hpp` headers for tf2, tf2_ros, cv_bridge, message_filters (present on both jazzy and lyrical).
- Guard the message_filters Subscriber QoS API (removed `rmw_qos_profile_t` overload → `rclcpp::QoS`) on `RCLCPP_VERSION_GTE(32,0,0)` so both distros compile.
- `-Wno-error=deprecated-declarations`: lyrical deprecates the remaining `rmw_qos_profile_t` QoS overloads this driver uses (image_transport, rclcpp); keep them warnings, not errors. (Full QoS modernization left as a follow-up.)
- Drop an unused `image_publisher/image_publisher.hpp` include.