### PR TITLE
[APG-2810] Report orbbec trigger failures to statsd

### DIFF
--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -893,8 +893,6 @@ class OBCameraNode {
 
   // Trigger failure monitor for automatic recovery
   std::unique_ptr<TriggerFailureMonitor> trigger_failure_monitor_;
-
-  // Publishes the camera name on each trigger failure, for metrics bridging.
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr trigger_failure_event_pub_ = nullptr;
 };
 }  // namespace orbbec_camera

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -893,5 +893,8 @@ class OBCameraNode {
 
   // Trigger failure monitor for automatic recovery
   std::unique_ptr<TriggerFailureMonitor> trigger_failure_monitor_;
+
+  // Publishes the camera name on each trigger failure, for metrics bridging.
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr trigger_failure_event_pub_ = nullptr;
 };
 }  // namespace orbbec_camera

--- a/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
+++ b/orbbec_camera/include/orbbec_camera/trigger_failure_monitor.h
@@ -29,6 +29,11 @@ class TriggerFailureMonitor {
   using TriggerCallback = std::function<void()>;
 
   /**
+   * @brief Callback type invoked on each recorded trigger failure
+   */
+  using FailureReportCallback = std::function<void()>;
+
+  /**
    * @brief Constructor
    * @param node ROS node for creating timer
    * @param logger Logger for diagnostic messages
@@ -72,6 +77,12 @@ class TriggerFailureMonitor {
    * @param callback Function to call to perform a trigger
    */
   void setTriggerCallback(TriggerCallback callback);
+
+  /**
+   * @brief Set callback invoked on each recorded trigger failure
+   * @param callback Function to call to report a failure
+   */
+  void setFailureReportCallback(FailureReportCallback callback);
 
   /**
    * @brief Record a trigger failure
@@ -120,6 +131,7 @@ class TriggerFailureMonitor {
   StreamControlCallback activate_callback_;         
   PipelineStatusCallback pipeline_status_callback_;
   TriggerCallback trigger_callback_;
+  FailureReportCallback failure_report_callback_;
   int failures_before_recovery_{2};
   double timer_period_seconds_{1.0}; 
   bool recovery_in_progress_{false};

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2240,6 +2240,16 @@ void OBCameraNode::setupTriggerFailureMonitor() {
       [this]() {
         TRY_EXECUTE_BLOCK(device_->triggerCapture());
       });
+
+  trigger_failure_event_pub_ = node_->create_publisher<std_msgs::msg::String>(
+      "/orbbec_trigger_failure_events", rclcpp::QoS(10));
+  trigger_failure_monitor_->setFailureReportCallback([this]() {
+    if (trigger_failure_event_pub_) {
+      std_msgs::msg::String failure_msg;
+      failure_msg.data = camera_name_;
+      trigger_failure_event_pub_->publish(failure_msg);
+    }
+  });
 }
 
 void OBCameraNode::setupDiagnosticUpdater() {

--- a/orbbec_camera/src/trigger_failure_monitor.cpp
+++ b/orbbec_camera/src/trigger_failure_monitor.cpp
@@ -48,8 +48,15 @@ void TriggerFailureMonitor::setTriggerCallback(TriggerCallback callback) {
   trigger_callback_ = callback;
 }
 
+void TriggerFailureMonitor::setFailureReportCallback(FailureReportCallback callback) {
+  failure_report_callback_ = callback;
+}
+
 void TriggerFailureMonitor::recordFailure() {
   consecutive_failures_++;
+  if (failure_report_callback_) {
+    failure_report_callback_();
+  }
 }
 
 void TriggerFailureMonitor::recordSuccess() {


### PR DESCRIPTION
Follows the same pattern as #29 (APG-2731, disconnect events).

- Publishes the camera name on `/orbbec_trigger_failure_events` (`std_msgs/String`, `QoS(10)`) on every recorded trigger failure, mirroring `/orbbec_disconnect_events`.
- Wired via a new `TriggerFailureMonitor` failure-report callback, so all failure paths report through a single point.
- Bridge side (statsd forwarding) is in apg_monitoring: locusrobotics/apg_monitoring#34